### PR TITLE
Add basic translation capabilities to MerC

### DIFF
--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -1,5 +1,6 @@
 import json
 from typing import Set
+import logging
 
 from macros import Macro, MacroMap
 from predicates.argument_altering import aa_invocation
@@ -9,6 +10,8 @@ from predicates.interface_equivalent import ie_def
 from predicates.metaprogramming import mp_invocation
 from predicates.property_categories import *
 from predicates.thunkizing import thunkizing_invocation
+
+logger = logging.getLogger(__name__)
 
 
 def easy_to_transform_invocation(i: Invocation,
@@ -79,7 +82,7 @@ def get_interface_equivalent_preprocessordata(results_file: str) -> Preprocessor
                     else:
                         unique_names[obj["Name"]] = obj
     except Exception as e:
-        print(f"Error reading file {results_file}: {e}")
+        logging.critical(f"Error reading file {results_file}: {e}")
         exit(1)
 
     # Filter out the None values.
@@ -106,8 +109,7 @@ def get_interface_equivalent_preprocessordata(results_file: str) -> Preprocessor
                 pd.mm[m] = set()
             if m.IsDefinitionLocationValid:
                 macroDefinitionLocationToMacroObject[entry["DefinitionLocation"]] = m
-            print(f"Adding macro {m.Name}")
-
+                logging.debug(f"Adding name {m.Name} to macroDefinitionLocationToMacroObject")
         elif entry["Kind"] == 'InspectedByCPP':
             pd.inspected_macro_names.add(entry["Name"])
         elif entry["Kind"] == "Include":

--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -1,6 +1,3 @@
-#!/usr/bin/python3
-
-import argparse
 import json
 from typing import Set
 
@@ -157,16 +154,3 @@ def get_interface_equivalent_preprocessordata(results_file: str) -> Preprocessor
 def get_interface_equivalent_translations(results_file: str) -> dict[Macro, str]:
     ie_pd = get_interface_equivalent_preprocessordata(results_file)
     return generate_macro_translations(ie_pd.mm)
-
-
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument('results_file', type=str)
-    ap.add_argument('-o', '--output_file')
-    args = ap.parse_args()
-
-    # Currently a stub, could easily modify to run on a single source file 
-
-
-if __name__ == '__main__':
-    main()

--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -40,6 +40,7 @@ def easy_to_transform_invocation(i: Invocation,
 def easy_to_transform_definition(m: Macro,
                                  pd: PreprocessorData,
                                  ie_invocations: Set[Invocation]):
+
     return all([
         easy_to_transform_invocation(i, pd, ie_invocations)
         for i in pd.mm[m]
@@ -118,8 +119,8 @@ def get_interface_equivalent_preprocessordata(results_file: str) -> Preprocessor
     for entry in filtered_entries:
         #print(entry)
         if entry["Kind"] == "Definition":
-            m = Macro(entry["Name"], entry["IsObjectLike"],
-                    entry["IsDefinitionLocationValid"], entry["Body"], entry["DefinitionLocation"], entry["EndDefinitionLocation"])
+            del entry["Kind"]
+            m = Macro(**entry)
             if m not in pd.mm:
                 pd.mm[m] = set()
             if m.IsDefinitionLocationValid: 

--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -2,6 +2,7 @@ import json
 from typing import Set, Any
 import logging
 from collections import Counter
+import re
 
 from macros import Macro, MacroMap, PreprocessorData, Invocation
 from predicates.argument_altering import aa_invocation
@@ -44,8 +45,11 @@ def generate_macro_translations(mm: MacroMap) -> dict[Macro, str | None]:
 
         # Static to avoid breaking the one definition rule
         if macro.IsFunctionLike:
-            # return only if not void
-            returnStatement = "return" if not invocation.TypeSignature.startswith("void") else ""
+            # Make sure we don't return for void functions,
+            # but do return for void * and anything else
+            pattern = r"void(?!\s*\*)"
+
+            returnStatement = "return" if not re.match(pattern, invocation.TypeSignature) else ""
             translationMap[macro] = f"static inline {invocation.TypeSignature} {{ {returnStatement} {macro.Body}; }}"
 
         elif macro.IsObjectLike:

--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -64,14 +64,13 @@ def generate_macro_translations(mm: MacroMap) -> dict[Macro, str]:
     return translationMap
 
 
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument('results_file', type=str)
-    ap.add_argument('-o', '--output_file')
-    args = ap.parse_args()
-
-    with open(args.results_file) as fp:
-        entries = json.load(fp)
+def get_interface_equivalent_preprocessordata(results_file: str) -> PreprocessorData:
+    try:
+        with open(results_file) as fp:
+            entries = json.load(fp)
+    except Exception as e:
+        print(f"Error reading file {results_file}: {e}")
+        exit(1)
 
     pd = PreprocessorData()
 
@@ -85,7 +84,7 @@ def main():
     macroDefinitionLocationToMacroObject: dict[str, Macro] = {}
 
     for entry in entries:
-        print(entry)
+        #print(entry)
         if entry["Kind"] == "Definition":
             m = Macro(entry["Name"], entry["IsObjectLike"],
                     entry["IsDefinitionLocationValid"], entry["Body"], entry["DefinitionLocation"], entry["EndDefinitionLocation"])
@@ -133,6 +132,21 @@ def main():
         tlna_src_pd.inspected_macro_names,
         tlna_src_pd.local_includes
     )
+
+    return ie_pd
+
+
+def get_interface_equivalent_translations(results_file: str) -> dict[Macro, str]:
+    ie_pd = get_interface_equivalent_preprocessordata(results_file)
+    return generate_macro_translations(ie_pd.mm)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('results_file', type=str)
+    ap.add_argument('-o', '--output_file')
+    args = ap.parse_args()
+
+    #output_translations(args.results_file, args.output_file)
 
 
 if __name__ == '__main__':

--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -2,13 +2,12 @@ import json
 from typing import Set, Any
 import logging
 
-from macros import Macro, MacroMap, PreprocessorData
+from macros import Macro, MacroMap, PreprocessorData, Invocation
 from predicates.argument_altering import aa_invocation
 from predicates.call_site_context_altering import csca_invocation
 from predicates.declaration_altering import da_invocation
 from predicates.interface_equivalent import ie_def
 from predicates.metaprogramming import mp_invocation
-from predicates.property_categories import *
 from predicates.thunkizing import thunkizing_invocation
 
 logger = logging.getLogger(__name__)

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -3,28 +3,10 @@ import os
 from analyze_transformations import Macro, PreprocessorData, InvocationPredicate, Invocation, get_interface_equivalent_preprocessordata, get_interface_equivalent_translations
 
 
-def get_interface_translations_on_dir(results_dir: str) -> list[dict[Macro, str]]:
-    translations : list[dict[Macro,str]] = []
-    for root, dirs, files in os.walk(results_dir):
-        for file in files:
-            if file.endswith('.maki'):
-                translation = get_interface_equivalent_translations(os.path.join(root, file))
-                
-                translations.append(translation)
-
-    return translations
-
-
-def translate_src_files(src_dir: str, out_dir: str, translations: list[dict[Macro, str]]) -> None:
-    # compress into one dictionary
-    translation_dict = {} 
-    for translation in translations:
-        for macro, translation in translation.items():
-            translation_dict[macro] = translation
-
+def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, str]) -> None:
     # dict of src files to their contents in lines
     src_file_contents : dict[str, list[str]] = {}
-    for macro, translation in translation_dict.items():
+    for macro, translation in translations.items():
         # open the source file
         startDefLocParts = macro.DefinitionLocation.split(":")
         endDefLocParts = macro.EndDefinitionLocation.split(":")
@@ -35,10 +17,6 @@ def translate_src_files(src_dir: str, out_dir: str, translations: list[dict[Macr
         if not src_file_path.startswith(src_dir):
             print(f"Skipping {src_file_path} because it is not in the source directory {src_dir}")
             continue
-
-        dst_file_path = os.path.join(out_dir, os.path.relpath(src_file_path, src_dir))
-
-        
 
         print(f"Translating {src_file_path}")
 
@@ -65,8 +43,9 @@ def translate_src_files(src_dir: str, out_dir: str, translations: list[dict[Macr
         # Insert the translation
         src_file_content[startLine] = translation + '\n'
 
-        # write the new source file
-
+    for src_file_path, src_file_content in src_file_contents.items():
+        dst_file_path = os.path.join(out_dir, os.path.relpath(src_file_path, src_dir))
+        os.makedirs(os.path.dirname(dst_file_path), exist_ok=True)
         with open(dst_file_path, 'w') as f:
             f.writelines(src_file_content)
 
@@ -76,17 +55,17 @@ def main():
     args = argparse.ArgumentParser()
 
     args.add_argument('input_src_dir', type=str)
-    args.add_argument('maki_results_dir', type=str)
+    args.add_argument('maki_results_path', type=str)
     args.add_argument('translation_output_dir', type=str)
 
     args = args.parse_args()
 
 
     input_src_dir = os.path.abspath(args.input_src_dir)
-    maki_results_dir = os.path.abspath(args.maki_results_dir)
+    maki_results_path = os.path.abspath(args.maki_results_path)
     translation_output_dir = args.translation_output_dir
 
-    translations = get_interface_translations_on_dir(maki_results_dir)
+    translations = get_interface_equivalent_translations(maki_results_path)
     translate_src_files(input_src_dir, translation_output_dir, translations)
 
 

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -7,6 +7,10 @@ def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, st
     # dict of src files to their contents in lines
     src_file_contents : dict[str, list[str]] = {}
     for macro, translation in translations.items():
+        # If we don't have a translation for this macro, skip it
+        if translation is None:
+            continue
+
         # open the source file
         startDefLocParts = macro.DefinitionLocation.split(":")
         endDefLocParts = macro.EndDefinitionLocation.split(":")
@@ -29,8 +33,8 @@ def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, st
         else:
             src_file_content = src_file_contents[src_file_path]
 
+
         # replace macro with translation
-    
         # Clear lines between start and end definition location
         startLine = int(startDefLocParts[1]) - 1
         endLine = int(endDefLocParts[1]) - 1

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -1,0 +1,39 @@
+import argparse
+import os
+import analyze_transformations
+from analyze_transformations import Macro, PreprocessorData, InvocationPredicate, Invocation, get_interface_equivalent_preprocessordata, get_interface_equivalent_translations
+
+
+def get_ie_pd_on_directory(results_dir: str) -> list[dict[Macro, str]]:
+    translations = []
+    for root, dirs, files in os.walk(results_dir):
+        for file in files:
+            if file.endswith('.maki'):
+                translation = get_interface_equivalent_translations(os.path.join(root, file))
+                
+                for macro, translation in translation.items():
+                    print(f"{macro} -> {translation}")
+
+
+
+
+
+def main():
+    args = argparse.ArgumentParser()
+
+    args.add_argument('input_src_dir', type=str)
+    args.add_argument('maki_results_dir', type=str)
+    args.add_argument('translation_output_dir', type=str)
+
+    args = args.parse_args()
+
+    input_src_dir = args.input_src_dir
+    maki_results_dir = args.maki_results_dir
+    translation_output_dir = args.translation_output_dir
+
+    get_ie_pd_on_directory(maki_results_dir)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -1,11 +1,14 @@
+#!/usr/bin/python3
+
 import argparse
 import os
-from analyze_transformations import Macro, PreprocessorData, InvocationPredicate, Invocation, get_interface_equivalent_preprocessordata, get_interface_equivalent_translations
+
+from analyze_transformations import Macro, get_interface_equivalent_translations
 
 
 def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, str]) -> None:
     # dict of src files to their contents in lines
-    src_file_contents : dict[str, list[str]] = {}
+    src_file_contents: dict[str, list[str]] = {}
     for macro, translation in translations.items():
         # If we don't have a translation for this macro, skip it
         if translation is None:
@@ -33,7 +36,6 @@ def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, st
         else:
             src_file_content = src_file_contents[src_file_path]
 
-
         # replace macro with translation
         # Clear lines between start and end definition location
         startLine = int(startDefLocParts[1]) - 1
@@ -54,7 +56,6 @@ def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, st
             f.writelines(src_file_content)
 
 
-
 def main():
     args = argparse.ArgumentParser()
 
@@ -63,7 +64,6 @@ def main():
     args.add_argument('translation_output_dir', type=str)
 
     args = args.parse_args()
-
 
     input_src_dir = os.path.abspath(args.input_src_dir)
     maki_results_path = os.path.abspath(args.maki_results_path)
@@ -75,4 +75,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -1,9 +1,12 @@
 #!/usr/bin/python3
 
 import argparse
+import logging
 import os
 
 from analyze_transformations import Macro, get_interface_equivalent_translations
+
+logger = logging.getLogger(__name__)
 
 
 def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, str]) -> None:
@@ -22,10 +25,10 @@ def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, st
 
         # only open files in src dir
         if not src_file_path.startswith(src_dir):
-            print(f"Skipping {src_file_path} because it is not in the source directory {src_dir}")
+            logger.warning(f"Skipping {src_file_path} because it is not in the source directory {src_dir}")
             continue
 
-        print(f"Translating {src_file_path}")
+        logger.info(f"Translating {src_file_path}")
 
         src_file_content: list[str] = None
 
@@ -44,7 +47,7 @@ def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, st
         for i in range(startLine, endLine + 1):
             src_file_content[i] = '\n'
 
-        print(f"Translation: {translation}")
+        logger.debug(f"Translation for {src_file_path}: {translation}")
 
         # Insert the translation
         src_file_content[startLine] = translation + '\n'
@@ -57,17 +60,20 @@ def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, st
 
 
 def main():
-    args = argparse.ArgumentParser()
+    ap = argparse.ArgumentParser()
 
-    args.add_argument('input_src_dir', type=str)
-    args.add_argument('maki_results_path', type=str)
-    args.add_argument('translation_output_dir', type=str)
-
-    args = args.parse_args()
+    ap.add_argument('input_src_dir', type=str)
+    ap.add_argument('maki_results_path', type=str)
+    ap.add_argument('translation_output_dir', type=str)
+    ap.add_argument("-v", "--verbose", action='store_true')
+    args = ap.parse_args()
 
     input_src_dir = os.path.abspath(args.input_src_dir)
     maki_results_path = os.path.abspath(args.maki_results_path)
     translation_output_dir = args.translation_output_dir
+
+    log_level = logging.INFO if args.verbose else logging.WARNING
+    logging.basicConfig(level=log_level)
 
     translations = get_interface_equivalent_translations(maki_results_path)
     translate_src_files(input_src_dir, translation_output_dir, translations)

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -1,20 +1,74 @@
 import argparse
 import os
-import analyze_transformations
 from analyze_transformations import Macro, PreprocessorData, InvocationPredicate, Invocation, get_interface_equivalent_preprocessordata, get_interface_equivalent_translations
 
 
-def get_ie_pd_on_directory(results_dir: str) -> list[dict[Macro, str]]:
-    translations = []
+def get_interface_translations_on_dir(results_dir: str) -> list[dict[Macro, str]]:
+    translations : list[dict[Macro,str]] = []
     for root, dirs, files in os.walk(results_dir):
         for file in files:
             if file.endswith('.maki'):
                 translation = get_interface_equivalent_translations(os.path.join(root, file))
                 
-                for macro, translation in translation.items():
-                    print(f"{macro} -> {translation}")
+                translations.append(translation)
+
+    return translations
 
 
+def translate_src_files(src_dir: str, out_dir: str, translations: list[dict[Macro, str]]) -> None:
+    # compress into one dictionary
+    translation_dict = {} 
+    for translation in translations:
+        for macro, translation in translation.items():
+            translation_dict[macro] = translation
+
+    # dict of src files to their contents in lines
+    src_file_contents : dict[str, list[str]] = {}
+    for macro, translation in translation_dict.items():
+        # open the source file
+        startDefLocParts = macro.DefinitionLocation.split(":")
+        endDefLocParts = macro.EndDefinitionLocation.split(":")
+
+        src_file_path = startDefLocParts[0]
+
+        # only open files in src dir
+        if not src_file_path.startswith(src_dir):
+            print(f"Skipping {src_file_path} because it is not in the source directory {src_dir}")
+            continue
+
+        dst_file_path = os.path.join(out_dir, os.path.relpath(src_file_path, src_dir))
+
+        
+
+        print(f"Translating {src_file_path}")
+
+        src_file_content: list[str] = None
+
+        if src_file_path not in src_file_contents:
+            with open(src_file_path, 'r') as f:
+                src_file_contents[src_file_path] = f.readlines()
+                src_file_content = src_file_contents[src_file_path]
+        else:
+            src_file_content = src_file_contents[src_file_path]
+
+        # replace macro with translation
+    
+        # Clear lines between start and end definition location
+        startLine = int(startDefLocParts[1]) - 1
+        endLine = int(endDefLocParts[1]) - 1
+
+        for i in range(startLine, endLine + 1):
+            src_file_content[i] = '\n'
+
+        print(f"Translation: {translation}")
+
+        # Insert the translation
+        src_file_content[startLine] = translation + '\n'
+
+        # write the new source file
+
+        with open(dst_file_path, 'w') as f:
+            f.writelines(src_file_content)
 
 
 
@@ -27,11 +81,13 @@ def main():
 
     args = args.parse_args()
 
-    input_src_dir = args.input_src_dir
-    maki_results_dir = args.maki_results_dir
+
+    input_src_dir = os.path.abspath(args.input_src_dir)
+    maki_results_dir = os.path.abspath(args.maki_results_dir)
     translation_output_dir = args.translation_output_dir
 
-    get_ie_pd_on_directory(maki_results_dir)
+    translations = get_interface_translations_on_dir(maki_results_dir)
+    translate_src_files(input_src_dir, translation_output_dir, translations)
 
 
 if __name__ == '__main__':

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -30,7 +30,7 @@ def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, st
 
         logger.info(f"Translating {src_file_path}")
 
-        src_file_content: list[str] = None
+        src_file_content: list[str]
 
         if src_file_path not in src_file_contents:
             with open(src_file_path, 'r') as f:

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -62,21 +62,25 @@ def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, st
 def main():
     ap = argparse.ArgumentParser()
 
-    ap.add_argument('input_src_dir', type=str)
-    ap.add_argument('maki_results_path', type=str)
-    ap.add_argument('translation_output_dir', type=str)
-    ap.add_argument("-v", "--verbose", action='store_true')
+    ap.add_argument('-i', '--input_src_dir', type=str, required=True,
+                    help='Path to the program source directory')
+    ap.add_argument('-m', '--maki_analysis_file', type=str, required=True,
+                    help='Path to the maki analysis file.')
+    ap.add_argument('-o', '--output_translation_dir', type=str, required=True,
+                    help='Output directory for translated source files.')
+    ap.add_argument('-v', '--verbose', action='store_true',
+                    help='Enable verbose logging')
     args = ap.parse_args()
 
     input_src_dir = os.path.abspath(args.input_src_dir)
-    maki_results_path = os.path.abspath(args.maki_results_path)
-    translation_output_dir = args.translation_output_dir
+    maki_analysis_path = os.path.abspath(args.maki_analysis_file)
+    output_translation_dir = args.output_translation_dir
 
     log_level = logging.INFO if args.verbose else logging.WARNING
     logging.basicConfig(level=log_level)
 
-    translations = get_interface_equivalent_translations(maki_results_path)
-    translate_src_files(input_src_dir, translation_output_dir, translations)
+    translations = get_interface_equivalent_translations(maki_analysis_path)
+    translate_src_files(input_src_dir, output_translation_dir, translations)
 
 
 if __name__ == '__main__':

--- a/macros.py
+++ b/macros.py
@@ -8,6 +8,7 @@ class Macro:
     Name: str
     IsObjectLike: bool
     IsDefinitionLocationValid: bool
+    IsDefinedAtGlobalScope: bool
     Body: str
     DefinitionLocation: str
     EndDefinitionLocation: str

--- a/macros.py
+++ b/macros.py
@@ -50,6 +50,7 @@ class Invocation:
     DoesAnyArgumentContainDeclRefExpr: bool
 
     IsHygienic: bool
+    IsICERepresentableByInt32: bool
     IsDefinitionLocationValid: bool
     IsInvocationLocationValid: bool
     IsObjectLike: bool

--- a/macros.py
+++ b/macros.py
@@ -1,6 +1,5 @@
-from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import DefaultDict, Literal, Set
+from typing import Literal, Set
 
 
 @dataclass(frozen=True)
@@ -266,11 +265,11 @@ class Invocation:
         return self.MustUseMetaprogrammingToTransform
 
 
-MacroMap = DefaultDict[Macro, Set[Invocation]]
+MacroMap = dict[Macro, Set[Invocation]]
 
 
 @dataclass
 class PreprocessorData:
-    mm: MacroMap = field(default_factory=lambda: defaultdict(set))
+    mm: MacroMap = field(default_factory=dict)
     inspected_macro_names: Set[str] = field(default_factory=set)
     local_includes: Set[str] = field(default_factory=set)

--- a/predicates/interface_equivalent.py
+++ b/predicates/interface_equivalent.py
@@ -14,6 +14,9 @@ def ie_def(m: Macro, pd: PreprocessorData) -> bool:
     # All invocations must have the same type signature
     if len(set([i.TypeSignature for i in is_])) != 1:
         return False
+    # The macro must be defined at global scope
+    if not m.IsDefinedAtGlobalScope:
+        return False
     return (
         (m.IsObjectLike and all([
             all([

--- a/run_maki_on_compile_commands.py
+++ b/run_maki_on_compile_commands.py
@@ -1,0 +1,82 @@
+import argparse
+from dataclasses import dataclass
+import os
+import json
+import subprocess
+
+@dataclass(frozen=True)
+class CompileCommand:
+    directory: str
+    arguments: list[str]
+    file: str
+
+    @staticmethod
+    def from_json(json: dict):
+        return CompileCommand(
+            directory=json["directory"],
+            arguments=json["arguments"],
+            file=json["file"]
+        )
+
+
+def run_maki_on_compile_command(cc: CompileCommand, src_dir: str, maki_so_path: str, out_dir: str):
+    # Enter source directory
+    os.chdir(src_dir)
+
+    print(os.path.relpath(cc.file, src_dir))
+
+    args = cc.arguments
+    # pass cpp2c plugin shared library file
+    args[0] = "clang"
+    args.insert(1, f'-fplugin={maki_so_path}')
+    # at the very end, specify that we are only doing syntactic analysis
+    # so as to not waste time compiling
+    args.append('-fsyntax-only')
+
+    dst_file = os.path.join(out_dir, os.path.relpath(cc.file, src_dir))
+
+    # Create the output directory if it doesn't exist
+    os.makedirs(os.path.dirname(dst_file), exist_ok=True)
+
+    # Change the file extension to .maki
+    root, _ = os.path.splitext(dst_file)
+    dst_file = root + '.maki'
+
+    print(" ".join(args))
+    with open(dst_file, 'w') as ofp:
+        os.chdir(os.path.dirname(cc.file))
+        process = subprocess.run(args, stdout=ofp, stderr=subprocess.PIPE)
+
+        # stderr
+        if process.stderr:
+            print(process.stderr)
+
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("maki_so_path", type=str)
+    ap.add_argument("src_dir", type=str)
+    ap.add_argument("compile_commands", type=str)
+    ap.add_argument("out_dir", type=str)
+    args = ap.parse_args()
+
+    maki_so_path = os.path.abspath(args.maki_so_path)
+    src_dir = os.path.abspath(args.src_dir)
+    compile_commands = os.path.abspath(args.compile_commands)
+    out_dir = os.path.abspath(args.out_dir)
+
+    # Load the compile_commands.json file (fail if it doesn't exist)
+    try:
+        with open(compile_commands) as fp:
+            compile_commands = json.load(fp)
+    except FileNotFoundError:
+        print(f"Could not find compile_commands.json in {src_dir}")
+    
+    compile_commands = [CompileCommand.from_json(cc) for cc in compile_commands]
+
+    for cc in compile_commands:
+        run_maki_on_compile_command(cc, src_dir, maki_so_path, out_dir)
+
+if __name__ == "__main__":
+    main()

--- a/run_maki_on_compile_commands.py
+++ b/run_maki_on_compile_commands.py
@@ -32,7 +32,7 @@ def run_maki_on_compile_command(cc: CompileCommand, maki_so_path: str) -> dict[s
 
     args = cc.arguments
     # pass cpp2c plugin shared library file
-    args[0] = "clang"
+    args[0] = "/usr/bin/clang-17"
     args.insert(1, f'-fplugin={maki_so_path}')
     args[-1] = cc.file
     # at the very end, specify that we are only doing syntactic analysis
@@ -49,13 +49,13 @@ def run_maki_on_compile_command(cc: CompileCommand, maki_so_path: str) -> dict[s
         # lot of build processes do include paths relative to source file directory
         os.chdir(cc.directory)
 
-        logger.info(f"Compiling {cc.file} with args {" ".join(args)}")
+        logger.info(f"Compiling {cc.file} with args {' '.join(args)}")
 
         process = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         # stderr
         if process.stderr:
-            logger.warning(f"clang stderr with args {" ".join(args)}:")
+            logger.warning(f"clang stderr with args {' '.join(args)}:")
             logger.warning(f"{process.stderr.decode()}")
 
         return json.loads(process.stdout.decode())

--- a/run_maki_on_compile_commands.py
+++ b/run_maki_on_compile_commands.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import argparse
 from dataclasses import dataclass
 import os
@@ -5,6 +7,7 @@ import json
 import subprocess
 import concurrent.futures
 import queue
+
 
 @dataclass(frozen=True)
 class CompileCommand:
@@ -21,8 +24,8 @@ class CompileCommand:
         )
 
 
-def run_maki_on_compile_command(cc: CompileCommand, src_dir: str, maki_so_path: str, out_file_path: str, result_queue : queue.Queue) -> None:
-
+def run_maki_on_compile_command(cc: CompileCommand, src_dir: str, maki_so_path: str, out_file_path: str,
+                                result_queue: queue.Queue) -> None:
     args = cc.arguments
     # pass cpp2c plugin shared library file
     args[0] = "clang"
@@ -42,7 +45,7 @@ def run_maki_on_compile_command(cc: CompileCommand, src_dir: str, maki_so_path: 
     try:
         # lot of build processes do include paths relative to source file directory
         os.chdir(cc.directory)
-        
+
         print(f"Compiling {cc.file} with args {" ".join(args)}")
         process = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -53,6 +56,7 @@ def run_maki_on_compile_command(cc: CompileCommand, src_dir: str, maki_so_path: 
     except subprocess.CalledProcessError as e:
         print(f"Error running maki on {cc.file}: {e}")
         print(e.stderr)
+
 
 def main():
     ap = argparse.ArgumentParser()
@@ -75,7 +79,7 @@ def main():
             compile_commands = json.load(fp)
     except FileNotFoundError:
         print(f"Could not find compile_commands.json in {src_dir}")
-    
+
     compile_commands = [CompileCommand.from_json(cc) for cc in compile_commands]
 
     # Store results in queue

--- a/run_maki_on_compile_commands.py
+++ b/run_maki_on_compile_commands.py
@@ -32,6 +32,10 @@ def run_maki_on_compile_command(cc: CompileCommand, src_dir: str, maki_so_path: 
     # so as to not waste time compiling
     args.append('-fsyntax-only')
 
+    # Add ignore flags for system headers, builtins, and invalid locations
+    args.append('-fplugin-arg-maki---no-system-macros')
+    args.append('-fplugin-arg-maki---no-builtin-macros')
+    args.append('-fplugin-arg-maki---no-invalid-macros')
 
     print(" ".join(args))
 

--- a/run_maki_on_compile_commands.py
+++ b/run_maki_on_compile_commands.py
@@ -8,6 +8,7 @@ import json
 import subprocess
 from functools import partial
 import concurrent.futures
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ class CompileCommand:
         )
 
 
-def run_maki_on_compile_command(cc: CompileCommand, maki_so_path: str) -> json:
+def run_maki_on_compile_command(cc: CompileCommand, maki_so_path: str) -> dict[str, Any]:
 
     args = cc.arguments
     # pass cpp2c plugin shared library file
@@ -54,11 +55,13 @@ def run_maki_on_compile_command(cc: CompileCommand, maki_so_path: str) -> json:
 
         # stderr
         if process.stderr:
-            logger.warning(f"clang stderr: {process.stderr}")
+            logger.warning(f"clang stderr with args {" ".join(args)}:")
+            logger.warning(f"{process.stderr.decode()}")
 
-        return json.loads(process.stdout)
+        return json.loads(process.stdout.decode())
     except subprocess.CalledProcessError as e:
         logger.exception(f"Error running maki with args {args} on {cc.file}: {e}")
+        return {}
 
 
 def main():


### PR DESCRIPTION
This PR adds basic translation capabilities to MerC.

`emit_translations.py` handles the generation of translated sources files by looking at the input source directory, taking a Maki results file and calling into `analyze_transformations.py` to generate transformations, and modifies the file as needed.

`run_maki_on_compile_commands.py`  is script to iteratively run Maki over a `compile_commands.json` file and output results into a single results file that can be used with `emit_translations.py`.

Transformation capabilities are currently limited and only work under certain conditions (i.e one definition per macro, in a global scope). Further PRs will expand scope of translatable macros.