### PR TITLE
Handle Maki property IsInvokedWhereConstantExpressionRequired

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -73,6 +73,7 @@ class Invocation:
     IsInvokedWhereModifiableValueRequired: bool
     IsInvokedWhereAddressableValueRequired: bool
     IsInvokedWhereICERequired: bool
+    IsInvokedWhereConstantExpressionRequired: bool
 
     IsAnyArgumentExpandedWhereModifiableValueRequired: bool
     IsAnyArgumentExpandedWhereAddressableValueRequired: bool


### PR DESCRIPTION
These changes handle the new property `IsInvokedWhereConstantExpression` and add new logic during the translation phase.

For object like macros:
If we have an ICE that is representable by a 32-bit int, translate it to an enum.

Otherwise, if it is not invoked where an ICE is required OR a constant expression is required, make it a static const variable.

Otherwise, we cannot translate this macro.