### PR TITLE
Add handling of function types

### DIFF
--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -43,6 +43,18 @@ def generate_macro_translations(mm: MacroMap) -> dict[Macro, str | None]:
         invocation = next(iter(invocations), None)
         assert invocation is not None
 
+        # If any part of the type signature has a function pointer
+        invocation_has_function_type = \
+            any([i.IsExpansionTypeFunctionType or i.IsAnyArgumentTypeFunctionType for i in invocations])
+
+        # For now, skip translating anything with a function pointer type
+        # As clang does not output the correct C syntax for these
+        # TODO(Joey): Implement a way to translate these
+        if invocation_has_function_type:
+            logger.debug(f"Skipping {macro.Name} as it has a function pointer type")
+            translationMap[macro] = None
+            continue
+
         # Static to avoid breaking the one definition rule
         if macro.IsFunctionLike:
             # Make sure we don't return for void functions,

--- a/macros.py
+++ b/macros.py
@@ -63,12 +63,14 @@ class Invocation:
     IsExpansionTypeLocalType: bool
     IsExpansionTypeDefinedAfterMacro: bool
     IsExpansionTypeVoid: bool
+    IsExpansionTypeFunctionType: bool
 
     IsAnyArgumentTypeNull: bool
     IsAnyArgumentTypeAnonymous: bool
     IsAnyArgumentTypeLocalType: bool
     IsAnyArgumentTypeDefinedAfterMacro: bool
     IsAnyArgumentTypeVoid: bool
+    IsAnyArgumentTypeFunctionType: bool
 
     IsInvokedWhereModifiableValueRequired: bool
     IsInvokedWhereAddressableValueRequired: bool


### PR DESCRIPTION
Add support for new Maki properties `IsExpansionTypeFunctionType` and `IsAnyArgumentTypeFunctionType`.

For now, since clang doesn't output the correct syntax for function pointers in it's type signatures, skip translating any macro with a function pointer.