### PR TITLE
Add logic to handle preserving multiline comments

### DIFF
--- a/emit_translations.py
+++ b/emit_translations.py
@@ -48,10 +48,9 @@ def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, st
 
         # Some code bases may define macros with an opening comment on the last line,
         # preserve it here
+        endLineComment = ''
         if '/*' in endLineContent.strip() and '*/' not in endLineContent.strip():
                 endLineComment = '/*' + endLineContent.split('/*', 1)[1]
-        else:
-            endLineComment = ''
 
         for i in range(startLine, endLine + 1):
             src_file_content[i] = '\n'

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -44,13 +44,25 @@ def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, st
         startLine = int(startDefLocParts[1]) - 1
         endLine = int(endDefLocParts[1]) - 1
 
+        endLineContent = src_file_content[endLine]
+
+        # Some code bases may define macros with an opening comment on the last line,
+        # preserve it here
+        if '/*' in endLineContent.strip() and '*/' not in endLineContent.strip():
+                endLineComment = '/*' + endLineContent.split('/*', 1)[1]
+        else:
+            endLineComment = ''
+
         for i in range(startLine, endLine + 1):
             src_file_content[i] = '\n'
 
         logger.debug(f"Translation for {src_file_path}: {translation}")
 
         # Insert the translation
-        src_file_content[startLine] = translation + '\n'
+        src_file_content[startLine] = translation
+
+        # Append the comment back to the end of the line
+        src_file_content[endLine] += endLineComment + '\n'
 
     for src_file_path, src_file_content in src_file_contents.items():
         dst_file_path = os.path.join(out_dir, os.path.relpath(src_file_path, src_dir))

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -48,6 +48,7 @@ def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, st
 
         # Some code bases may define macros with an opening comment on the last line,
         # preserve it here
+        # TODO(Joey): This is a really hacky way to do this, look into a parser for this.
         endLineComment = ''
         if '/*' in endLineContent.strip() and '*/' not in endLineContent.strip():
                 endLineComment = '/*' + endLineContent.split('/*', 1)[1]


### PR DESCRIPTION
Some code bases define multiline comments starting at the end of the macro like this:
```c
#define A 1 /* comment start


comment end */
```
Without this we incorrectly translate this to
```c
static const int A 1;


comment end */
``` 
and cause syntax errors.

Add some logic to preserve any comment at the last line of a macro and append it after we complete our translation.