### PR TITLE
Handle command field in compile_commands

### DIFF
--- a/run_maki_on_compile_commands.py
+++ b/run_maki_on_compile_commands.py
@@ -28,6 +28,8 @@ class CompileCommand:
             arguments = json_file["arguments"]
         elif "command" in json_file:
             arguments = json_file["command"].split()
+        else:
+            raise ValueError("Compile command must have either 'arguments' or 'command' key")
 
         return CompileCommand(
             directory=json_file["directory"],

--- a/run_maki_on_compile_commands.py
+++ b/run_maki_on_compile_commands.py
@@ -21,9 +21,17 @@ class CompileCommand:
 
     @staticmethod
     def from_json(json_file: dict) -> 'CompileCommand':
+
+        # compile_commands.json can either have "arguments" or "command" key
+        # We always want a list of arguments, so split command if there is no arguments list
+        if "arguments" in json_file:
+            arguments = json_file["arguments"]
+        elif "command" in json_file:
+            arguments = json_file["command"].split()
+
         return CompileCommand(
             directory=json_file["directory"],
-            arguments=json_file["arguments"],
+            arguments=arguments,
             file=json_file["file"]
         )
 


### PR DESCRIPTION
The [compile_commands.json format](https://clang.llvm.org/docs/JSONCompilationDatabase.html#format) requires that each compile command has arguments (argv list) OR command (shell escaped string). 

We only handle arguments, so add logic to handle commands by checking if it exists and splitting it.

Tested against codebases that generate command instead (neovim), and codebases that generate arguments. Also tested with none of the above and verified exception was raised.