### PR TITLE
Change entry name for Include validity to correct Maki output

### DIFF
--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -137,7 +137,7 @@ def get_interface_equivalent_preprocessordata(results_file: str) -> Preprocessor
         elif entry["Kind"] == 'InspectedByCPP':
             pd.inspected_macro_names.add(entry["Name"])
         elif entry["Kind"] == "Include":
-            if entry["IsIncludeLocationValid"]:
+            if entry["IsValid"]:
                 pd.local_includes.add(entry["IncludeName"])
         elif entry["Kind"] == 'Invocation':
             del entry["Kind"]


### PR DESCRIPTION
[Maki had a bug](https://github.com/appleseedlab/maki/issues/58) where Include information was never printed out. At some point the field for checking if the Include was valid was changed from `IsIncludeLocationValid` to `IsValid`, and MerC did not change this, which caused a runtime error.

Adjust to new name.

Tested and verified crash went away and include logic worked.