### PR TITLE
Skip translating macros if body contains a DeclRefExpr

### DIFF
--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -56,6 +56,7 @@ def generate_macro_translations(mm: MacroMap) -> dict[Macro, str | None]:
             continue
 
         # If body contains a DeclRefExpr and is in a header file, skip
+        # TODO(Joey/Brent): Find better way on Maki side to handle this
         invocation_has_decl_ref_expr = invocation.DoesBodyContainDeclRefExpr
         if invocation_has_decl_ref_expr and invocation.DefinitionLocationFilename.endswith(".h"):
             logger.debug(f"Skipping {macro.Name} as it contains a DeclRefExpr")

--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -55,6 +55,14 @@ def generate_macro_translations(mm: MacroMap) -> dict[Macro, str | None]:
             translationMap[macro] = None
             continue
 
+        # If body contains a DeclRefExpr and is in a header file, skip
+        invocation_has_decl_ref_expr = invocation.DoesBodyContainDeclRefExpr
+        if invocation_has_decl_ref_expr and invocation.DefinitionLocationFilename.endswith(".h"):
+            logger.debug(f"Skipping {macro.Name} as it contains a DeclRefExpr")
+            translationMap[macro] = None
+            continue
+
+
         # Static to avoid breaking the one definition rule
         if macro.IsFunctionLike:
             # Make sure we don't return for void functions,


### PR DESCRIPTION
When translating macros in header files, we can't guarantee what set of symbols will be available to it when it is defined. 

I.e, programs like bash may:
* Declare a macro in Header A.
* Invoke this macro in the definition of another macro in Header B (but not include Header A in it).
* Include both headers in a source file to use Header B's macro. 
 
This causes no issues, but if Header B were to be included on it's own, the symbol referenced from Header A would be undefined.

To avoid this from happening, for now we must ignore any macro definitions who's body contains a DeclRefExpr.


Example: The definition of `TAU` contains a nested call to `PI`, and while `PI` is defined when `TAU` is invoked in `main.c`, it is not defined in `tau.h`. Without this PR's changes, MerC would translate `TAU` to a function (since it is only invoked in `main.c` where `PI` is defined before `TAU` is) and if one were to then try to parse `tau.h` they would receive an undefined reference to `PI`:

```c
// pi.h
#define PI 3.14
```

```c
// tau.h
#define TAU (2 * PI)
```

```c
// main.c
#include "pi.h"
#include "tau.h"
int main(void) { return TAU; }
```

MerC would translate `tau.h` to:

```c
// tau.h (translated)
static const float TAU = ( 2 * PI );
```

`tau.h` does not include `pi.h`, so if one were to include `tau.h` in a source file without first including `pi.h`, then this translation would create an undefined reference error.