### PR TITLE
Allow configuration of int size for enum translation

### DIFF
--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -29,10 +29,10 @@ def easy_to_transform_invocation(i: Invocation,
 def easy_to_transform_definition(m: Macro,
                                  pd: PreprocessorData,
                                  ie_invocations: Set[Invocation]):
-    return all([
+    return all(
         easy_to_transform_invocation(i, pd, ie_invocations)
         for i in pd.mm[m]
-    ])
+    )
 
 
 def generate_macro_translations(mm: MacroMap,
@@ -47,7 +47,7 @@ def generate_macro_translations(mm: MacroMap,
 
         # If any part of the type signature has a function pointer
         invocation_has_function_type = \
-            any([i.IsExpansionTypeFunctionType or i.IsAnyArgumentTypeFunctionType for i in invocations])
+            any(i.IsExpansionTypeFunctionType or i.IsAnyArgumentTypeFunctionType for i in invocations)
 
         # For now, skip translating anything with a function pointer type
         # As clang does not output the correct C syntax for these
@@ -71,13 +71,13 @@ def generate_macro_translations(mm: MacroMap,
             # to be translatable to an enum
 
             can_translate_to_enum = all(
-                    [i.CanBeTurnedIntoEnumWithIntSize(translation_config.int_size)
-                     for i in invocations if i.IsInvokedWhereICERequired]
+                    i.CanBeTurnedIntoEnumWithIntSize(translation_config.int_size)
+                    for i in invocations if i.IsInvokedWhereICERequired
                     )
 
-            invoked_where_ICE_required = any([i.IsInvokedWhereICERequired for i in invocations])
+            invoked_where_ICE_required = any(i.IsInvokedWhereICERequired for i in invocations)
             invoked_where_constant_expression_required = \
-                any([i.IsInvokedWhereConstantExpressionRequired for i in invocations])
+                any(i.IsInvokedWhereConstantExpressionRequired for i in invocations)
 
             # If we're an ICE and translatable to an enum, translate to enum
             if invoked_where_ICE_required and can_translate_to_enum:
@@ -151,7 +151,7 @@ def get_interface_equivalent_preprocessordata(results_file: str) -> Preprocessor
                 m = macroDefinitionLocationToMacroObject[i.DefinitionLocation]
                 # Only record unique invocations - two invocations may have the same
                 # location if they are the same nested invocation
-                if all([j.InvocationLocation != i.InvocationLocation for j in pd.mm[m]]):
+                if all(j.InvocationLocation != i.InvocationLocation for j in pd.mm[m]):
                     pd.mm[m].add(i)
 
     # src_pd only records preprocessor data about source macros

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -85,7 +85,7 @@ def main():
                     help='Enable verbose logging')
 
     # Translation args
-    ap.add_argument('--int-size', type=int, choices=list(IntSize), default=IntSize.Int32,
+    ap.add_argument('--int-size', type=int, choices=[size.value for size in IntSize], default=IntSize.Int32,
                     help='Size of int type in bits')
 
     args = ap.parse_args()

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -5,11 +5,12 @@ import logging
 import os
 
 from analyze_transformations import Macro, get_interface_equivalent_translations
+from translationconfig import TranslationConfig, IntSize
 
 logger = logging.getLogger(__name__)
 
 
-def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, str]) -> None:
+def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, str | None]) -> None:
     # dict of src files to their contents in lines
     src_file_contents: dict[str, list[str]] = {}
     for macro, translation in translations.items():
@@ -82,16 +83,25 @@ def main():
                     help='Output directory for translated source files.')
     ap.add_argument('-v', '--verbose', action='store_true',
                     help='Enable verbose logging')
+
+    # Translation args
+    ap.add_argument('--int-size', type=int, choices=list(IntSize), default=IntSize.Int32,
+                    help='Size of int type in bits')
+
     args = ap.parse_args()
 
     input_src_dir = os.path.abspath(args.input_src_dir)
     maki_analysis_path = os.path.abspath(args.maki_analysis_file)
     output_translation_dir = args.output_translation_dir
 
+    translation_config = TranslationConfig.from_args(args)
+
     log_level = logging.INFO if args.verbose else logging.WARNING
     logging.basicConfig(level=log_level)
 
-    translations = get_interface_equivalent_translations(maki_analysis_path)
+    translations = get_interface_equivalent_translations(maki_analysis_path,
+                                                         translation_config)
+
     translate_src_files(input_src_dir, output_translation_dir, translations)
 
 

--- a/macros.py
+++ b/macros.py
@@ -51,6 +51,7 @@ class Invocation:
 
     IsHygienic: bool
     IsICERepresentableByInt32: bool
+    IsICERepresentableByInt16: bool
     IsDefinitionLocationValid: bool
     IsInvocationLocationValid: bool
     IsObjectLike: bool

--- a/macros.py
+++ b/macros.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Literal, Set
+from translationconfig import IntSize
 
 
 @dataclass(frozen=True)
@@ -267,6 +268,11 @@ class Invocation:
     @property
     def SatisfiesALanguageSpecificProperty(self) -> bool:
         return self.MustUseMetaprogrammingToTransform
+        
+    def CanBeTurnedIntoEnumWithIntSize(self, int_size: IntSize) -> bool:
+        return self.CanBeTurnedIntoEnum and \
+        (self.IsICERepresentableByInt32 if int_size == IntSize.Int32
+         else self.IsICERepresentableByInt16)
 
 
 MacroMap = dict[Macro, Set[Invocation]]

--- a/translationconfig.py
+++ b/translationconfig.py
@@ -1,0 +1,16 @@
+import argparse
+from enum import IntEnum
+from dataclasses import dataclass
+
+class IntSize(IntEnum):
+    Int16 = 16
+    Int32 = 32
+
+@dataclass(frozen=True)
+class TranslationConfig:
+    int_size: IntSize = IntSize.Int32
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace):
+        # automatically iterate over args w/ same field names
+        return cls(**{field: getattr(args, field) for field in cls.__dataclass_fields__})


### PR DESCRIPTION
Add the command line arg `--int-size` to either set the size of an `int` to 32-bits (default) or 16-bits, to determine what we can and cannot translate to an enum.

To handle adding more config options down the road (use constexpr, etc), add the dataclass `TranslationConfig` with translation related configuration options that is passed to `generate_macro_translations`. Can be constructed by looking at an argparse namespace.

To easily check the property, add the method `CanBeTurnedIntoEnumWithIntSize` to Invocation. that takes an `IntSize` and checks it's properties to see if it can be represented with the given int size.

Closes #6.

Note: `generate_macro_translation` is starting to get large, will refactor in a later PR.

