### PR TITLE
Move macro translation logic into MacroTranslator class

### DIFF
--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -11,7 +11,6 @@ from predicates.declaration_altering import da_invocation
 from predicates.interface_equivalent import ie_def
 from predicates.metaprogramming import mp_invocation
 from predicates.thunkizing import thunkizing_invocation
-from translationconfig import TranslationConfig
 
 logger = logging.getLogger(__name__)
 

--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -34,72 +34,6 @@ def easy_to_transform_definition(m: Macro,
         for i in pd.mm[m]
     )
 
-
-def generate_macro_translations(mm: MacroMap,
-                                translation_config: TranslationConfig) -> dict[Macro, str | None]:
-    translationMap: dict[Macro, str | None] = {}
-
-    for macro, invocations in mm.items():
-        # We only need to look at the first invocation to determine the translation
-        # Already verified that all type signatures are the same
-        invocation = next(iter(invocations), None)
-        assert invocation is not None
-
-        # If any part of the type signature has a function pointer
-        invocation_has_function_type = \
-            any(i.IsExpansionTypeFunctionType or i.IsAnyArgumentTypeFunctionType for i in invocations)
-
-        # For now, skip translating anything with a function pointer type
-        # As clang does not output the correct C syntax for these
-        # TODO(Joey): Implement a way to translate these
-        if invocation_has_function_type:
-            logger.debug(f"Skipping {macro.Name} as it has a function pointer type")
-            translationMap[macro] = None
-            continue
-
-        # If body contains a DeclRefExpr and is in a header file, skip
-        # TODO(Joey/Brent): Find better way on Maki side to handle this
-        invocation_has_decl_ref_expr = invocation.DoesBodyContainDeclRefExpr
-        if invocation_has_decl_ref_expr and invocation.DefinitionLocationFilename.endswith(".h"):
-            logger.debug(f"Skipping {macro.Name} as it contains a DeclRefExpr")
-            translationMap[macro] = None
-            continue
-
-
-        # Static to avoid breaking the one definition rule
-        if macro.IsFunctionLike:
-            # Make sure we don't return for void functions,
-            # but do return for void * and anything else
-            pattern = r"void(?!\s*\*)"
-
-            returnStatement = "return" if not re.match(pattern, invocation.TypeSignature) else ""
-            translationMap[macro] = f"static inline {invocation.TypeSignature} {{ {returnStatement} {macro.Body}; }}"
-
-        elif macro.IsObjectLike:
-            # All invocations where an ICE is required must be representable by type int 
-            # to be translatable to an enum
-
-            can_translate_to_enum = all(
-                    i.CanBeTurnedIntoEnumWithIntSize(translation_config.int_size)
-                    for i in invocations if i.IsInvokedWhereICERequired
-                    )
-
-            invoked_where_ICE_required = any(i.IsInvokedWhereICERequired for i in invocations)
-            invoked_where_constant_expression_required = \
-                any(i.IsInvokedWhereConstantExpressionRequired for i in invocations)
-
-            # If we're an ICE and translatable to an enum, translate to enum
-            if invoked_where_ICE_required and can_translate_to_enum:
-                translationMap[macro] = f"enum {{ {macro.Name} = {macro.Body} }};"
-            # Not a constant expression or ICE so safe to translate to a static const
-            elif not invoked_where_constant_expression_required and not invoked_where_ICE_required:
-                translationMap[macro] = f"static const {invocation.TypeSignature} = {macro.Body};"
-            # If we're here, we're a constant expression but not an ICE - can't handle
-            else:
-                translationMap[macro] = None
-
-    return translationMap
-
 def filter_definitions(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
     # Count the number of definitions with a given name
     name_counts = Counter(obj["Name"] for obj in entries if obj["Kind"] == "Definition")
@@ -189,9 +123,3 @@ def get_interface_equivalent_preprocessordata(results_file: str) -> Preprocessor
     )
 
     return ie_pd
-
-
-def get_interface_equivalent_translations(results_file: str,
-                                          translation_config: TranslationConfig) -> dict[Macro, str | None]:
-    ie_pd = get_interface_equivalent_preprocessordata(results_file)
-    return generate_macro_translations(ie_pd.mm, translation_config)

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -4,7 +4,8 @@ import argparse
 import logging
 import os
 
-from analyze_transformations import Macro, get_interface_equivalent_translations
+from analyze_transformations import Macro, get_interface_equivalent_preprocessordata
+from macrotranslator import MacroTranslator
 from translationconfig import TranslationConfig, IntSize
 
 logger = logging.getLogger(__name__)
@@ -99,8 +100,9 @@ def main():
     log_level = logging.INFO if args.verbose else logging.WARNING
     logging.basicConfig(level=log_level)
 
-    translations = get_interface_equivalent_translations(maki_analysis_path,
-                                                         translation_config)
+    ie_pd = get_interface_equivalent_preprocessordata(maki_analysis_path)
+    translator = MacroTranslator(translation_config)
+    translations = translator.generate_macro_translations(ie_pd.mm)
 
     translate_src_files(input_src_dir, output_translation_dir, translations)
 

--- a/macrotranslator.py
+++ b/macrotranslator.py
@@ -1,0 +1,87 @@
+from macros import MacroMap, Macro, Invocation
+from translationconfig import TranslationConfig
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+
+class MacroTranslator:
+    def __init__(self, translation_config: TranslationConfig) -> None:
+        self.translation_config = translation_config
+
+    def generate_macro_translations(self,
+                                    mm: MacroMap) -> dict[Macro, str | None]:
+        translationMap: dict[Macro, str | None] = {}
+
+        for macro, invocations in mm.items():
+            translationMap[macro] = self.get_macro_translation(macro, invocations)
+
+        return translationMap
+
+    def get_macro_translation(self, macro: Macro, invocations: set[Invocation]) -> str | None:
+
+        if self.should_skip_macro(macro, invocations):
+            return None
+
+        if macro.IsFunctionLike:
+            return self.translate_function_like_macro(macro, invocations)
+        elif macro.IsObjectLike:
+            return self.translate_object_like_macro(macro, invocations)
+
+    def should_skip_macro(self, macro: Macro, invocations: set[Invocation]) -> bool:
+        # For now, skip translating anything with a function pointer type
+        # As Maki does not output the correct C syntax for these
+
+        # If any part of the type signature has a function pointer
+        invocation_has_function_type = \
+            any(i.IsExpansionTypeFunctionType or i.IsAnyArgumentTypeFunctionType for i in invocations)
+
+        # TODO(Joey): Implement a way to translate these
+        if invocation_has_function_type:
+            logger.debug(f"Skipping {macro.Name} as it has a function pointer type")
+            return True
+
+        # If body contains a DeclRefExpr and is in a header file, skip
+        # TODO(Joey/Brent): Find better way on Maki side to handle this
+        invocation = next(iter(invocations))
+
+        invocation_has_decl_ref_expr = invocation.DoesBodyContainDeclRefExpr
+        if invocation_has_decl_ref_expr and invocation.DefinitionLocationFilename.endswith(".h"):
+            logger.debug(f"Skipping {macro.Name} as it contains a DeclRefExpr")
+            return True
+
+        return False
+
+    def translate_function_like_macro(self, macro: Macro, invocations: set[Invocation]) -> str:
+        # Make sure we don't return for void functions,
+        # but do return for void * and anything else
+        pattern = r"void(?!\s*\*)"
+
+        invocation = next(iter(invocations))
+        returnStatement = "return" if not re.match(pattern, invocation.TypeSignature) else ""
+        return f"static inline {invocation.TypeSignature} {{ {returnStatement} {macro.Body}; }}"
+
+    def translate_object_like_macro(self, macro: Macro, invocations: set[Invocation]) -> str | None:
+        invocation = next(iter(invocations))
+
+        # All invocations where an ICE is required must be representable by type int
+        # to be translatable to an enum
+        can_translate_to_enum = all(
+            i.CanBeTurnedIntoEnumWithIntSize(self.translation_config.int_size)
+            for i in invocations if i.IsInvokedWhereICERequired
+        )
+
+        invoked_where_ICE_required = any(i.IsInvokedWhereICERequired for i in invocations)
+        invoked_where_constant_expression_required = \
+            any(i.IsInvokedWhereConstantExpressionRequired for i in invocations)
+
+        # If we're an ICE and translatable to an enum, translate to enum
+        if invoked_where_ICE_required and can_translate_to_enum:
+            return f"enum {{ {macro.Name} = {macro.Body} }};"
+        # Not a constant expression or ICE so safe to translate to a static const
+        elif not invoked_where_constant_expression_required and not invoked_where_ICE_required:
+            return f"static const {invocation.TypeSignature} = {macro.Body};"
+        # If we're here, we're a constant expression but not an ICE - can't handle
+        else:
+            return None

--- a/macrotranslator.py
+++ b/macrotranslator.py
@@ -21,7 +21,7 @@ class MacroTranslator:
 
     def get_macro_translation(self, macro: Macro, invocations: set[Invocation]) -> str | None:
 
-        if self.should_skip_macro(macro, invocations):
+        if self.should_skip_due_to_technical_limitations(macro, invocations):
             return None
 
         if macro.IsFunctionLike:
@@ -29,7 +29,17 @@ class MacroTranslator:
         elif macro.IsObjectLike:
             return self.translate_object_like_macro(macro, invocations)
 
-    def should_skip_macro(self, macro: Macro, invocations: set[Invocation]) -> bool:
+    def should_skip_due_to_technical_limitations(self, macro: Macro, invocations: set[Invocation]) -> bool:
+        """
+        Skips are due to technical limitations of Maki and MerC and not
+        due to irreconcilable differences in macro and C semantics.
+
+        These skips are subject to removal as Maki and MerC are improved.
+
+        Skips due to differences in macro and C semantics
+        are handled by predicates.interface_equivalent.ie_def
+        """
+
         # For now, skip translating anything with a function pointer type
         # As Maki does not output the correct C syntax for these
 

--- a/macrotranslator.py
+++ b/macrotranslator.py
@@ -56,10 +56,10 @@ class MacroTranslator:
     def translate_function_like_macro(self, macro: Macro, invocations: set[Invocation]) -> str:
         # Make sure we don't return for void functions,
         # but do return for void * and anything else
-        pattern = r"void(?!\s*\*)"
-
         invocation = next(iter(invocations))
-        returnStatement = "return" if not re.match(pattern, invocation.TypeSignature) else ""
+        is_void = invocation.IsExpansionTypeVoid
+
+        returnStatement = "return" if not is_void else ""
         return f"static inline {invocation.TypeSignature} {{ {returnStatement} {macro.Body}; }}"
 
     def translate_object_like_macro(self, macro: Macro, invocations: set[Invocation]) -> str | None:


### PR DESCRIPTION
Break up the logic of macro translations and move them from analyze transformations into MacroTranslator which handles taking a MacroMap and emitting all the translations.

This will make it easier to have a general MacroTranslationStats class as an instance member that can handle recording translation stats that we need and also just translation logic easier to understand.

Note that I'd like to make this project an actual package w/ sub-packages, and consider moving `run_maki_on_compile_commands.py` into a util script for Maki as it's entirely separate from the rest of MerC, but I'm more focused on getting evaluation done currently.

Tested and verified same translations were emitted on bash.