### PR TITLE
Add translation stat counter and CSV output

### DIFF
--- a/emit_translations.py
+++ b/emit_translations.py
@@ -4,7 +4,8 @@ import argparse
 import logging
 import os
 
-from analyze_transformations import Macro, get_interface_equivalent_preprocessordata
+from analyze_transformations import get_interface_equivalent_preprocessordata
+from macros import Macro
 from macrotranslator import MacroTranslator
 from translationconfig import TranslationConfig, IntSize
 
@@ -84,6 +85,8 @@ def main():
                     help='Output directory for translated source files.')
     ap.add_argument('-v', '--verbose', action='store_true',
                     help='Enable verbose logging')
+    ap.add_argument('--output-csv', type=str, required=False,
+                    help='Output the macro translations to a CSV file.')
 
     # Translation args
     ap.add_argument('--int-size', type=int, choices=[size.value for size in IntSize], default=IntSize.Int32,
@@ -105,6 +108,11 @@ def main():
     translations = translator.generate_macro_translations(ie_pd.mm)
 
     translate_src_files(input_src_dir, output_translation_dir, translations)
+
+    translator.translation_stats.print_totals()
+    if args.output_csv:
+        path = os.path.abspath(args.output_csv)
+        translator.translation_stats.output_csv(path)
 
 
 if __name__ == '__main__':

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -3,6 +3,7 @@
 import argparse
 import logging
 import os
+import pathlib
 
 from analyze_transformations import get_interface_equivalent_preprocessordata
 from macros import Macro
@@ -77,15 +78,15 @@ def translate_src_files(src_dir: str, out_dir: str, translations: dict[Macro, st
 def main():
     ap = argparse.ArgumentParser()
 
-    ap.add_argument('-i', '--input_src_dir', type=str, required=True,
+    ap.add_argument('-i', '--input_src_dir', type=pathlib.Path, required=True,
                     help='Path to the program source directory')
-    ap.add_argument('-m', '--maki_analysis_file', type=str, required=True,
+    ap.add_argument('-m', '--maki_analysis_file', type=pathlib.Path, required=True,
                     help='Path to the maki analysis file.')
-    ap.add_argument('-o', '--output_translation_dir', type=str, required=True,
+    ap.add_argument('-o', '--output_translation_dir', type=pathlib.Path, required=True,
                     help='Output directory for translated source files.')
     ap.add_argument('-v', '--verbose', action='store_true',
                     help='Enable verbose logging')
-    ap.add_argument('--output-csv', type=str, required=False,
+    ap.add_argument('--output-csv', type=pathlib.Path, required=False,
                     help='Output the macro translations to a CSV file.')
 
     # Translation args

--- a/macrotranslator.py
+++ b/macrotranslator.py
@@ -87,11 +87,16 @@ class MacroTranslator:
             any(i.IsInvokedWhereConstantExpressionRequired for i in invocations)
 
         # If we're an ICE and translatable to an enum, translate to enum
-        if invoked_where_ICE_required and can_translate_to_enum:
-            return f"enum {{ {macro.Name} = {macro.Body} }};"
-        # Not a constant expression or ICE so safe to translate to a static const
-        elif not invoked_where_constant_expression_required and not invoked_where_ICE_required:
+        if invoked_where_ICE_required:
+            if can_translate_to_enum:
+                return f"enum {{ {macro.Name} = {macro.Body} }};"
+            else:
+                # Can't fit into an enum
+                return None
+
+        # Not a constant expression (or ICE) so safe to translate to a static const
+        if not invoked_where_constant_expression_required:
             return f"static const {invocation.TypeSignature} = {macro.Body};"
-        # If we're here, we're a constant expression but not an ICE - can't handle
+        # We're a constant expression but not an ICE - can't handle
         else:
             return None

--- a/macrotranslator.py
+++ b/macrotranslator.py
@@ -1,8 +1,7 @@
 from macros import MacroMap, Macro, Invocation
 from translationconfig import TranslationConfig
 import logging
-import re
-from translationstats import MacroType, TranslationRecord, TranslationRecords, SkipRecord, MacroRecord
+from translationstats import TranslationRecord, TranslationRecords, SkipRecord, MacroRecord
 from translationstats import TranslationType
 from translationstats import SkipType
 

--- a/translationstats.py
+++ b/translationstats.py
@@ -1,0 +1,116 @@
+from dataclasses import dataclass, field
+from collections import Counter
+import sys
+from macros import Macro
+
+# 3.10 compatibility
+if sys.version_info <= (3, 10):
+    from enum import Enum
+    class StrEnum(str, Enum): pass
+else:
+    from enum import StrEnum
+
+class MacroType(StrEnum):
+    """
+    Types of macros that we can handle
+    """
+    OBJECT_LIKE = "object_like"
+    FUNCTION_LIKE = "function_like"
+
+class TranslatorAction(StrEnum):
+    pass
+
+class TranslationType(TranslatorAction):
+    VOID = "void"
+    NON_VOID = "non_void"
+    ENUM = "enum"
+    CONST_STATIC = "const_static"
+
+class SkipType(TranslatorAction):
+    BODY_CONTAINS_DECL_REF_EXPR = "body_contains_decl_ref_expr"
+    DEFINITION_HAS_FUNCTION_POINTER = "definition_has_function_pointer"
+
+    # Object-like specifics
+    CANT_FIT_ICE_IN_ENUM_SIZE = "cant_fit_ice_in_enum_size"
+    INVOCATION_REQUIRES_CONSTANT_EXPRESSION = "invocation_requires_constant_expression"
+
+@dataclass(slots=True)
+class MacroRecord:
+    """
+    Base class for all macro records
+    """
+    macro: Macro
+
+@dataclass(slots=True)
+class SkipRecord(MacroRecord):
+    skip_type: SkipType
+
+@dataclass(slots=True)
+class TranslationRecord(MacroRecord):
+    macro_translation: str
+    translation_type: TranslationType
+
+@dataclass()
+class TranslationRecords:
+    records_by_type: Counter[tuple[MacroType, TranslatorAction]] = field(default_factory=Counter)
+    translation_records: list[TranslationRecord] = field(default_factory=list)
+    skip_records: list[SkipRecord] = field(default_factory=list)
+
+    @property
+    def total_translated(self) -> int:
+        return len(self.translation_records)
+
+    @property
+    def total_skipped(self) -> int:
+        return len(self.skip_records)
+
+    def total_translated_by_type(self, macro_type: MacroType) -> int:
+        return len(list(record for record in self.translation_records if self._get_macro_type(record.macro) == macro_type))
+
+    def total_skipped_by_type(self, macro_type: MacroType) -> int:
+        return len(list(record for record in self.skip_records if self._get_macro_type(record.macro) == macro_type))
+
+    def _get_macro_type(self, macro: Macro) -> MacroType:
+        return MacroType.FUNCTION_LIKE if macro.IsFunctionLike else MacroType.OBJECT_LIKE
+
+    def add_translation_record(self, record: TranslationRecord) -> None:
+        macro_type = self._get_macro_type(record.macro)
+
+        self.translation_records.append(record)
+        self.records_by_type[(macro_type, record.translation_type)] += 1
+
+    def add_skip_record(self, record: SkipRecord):
+        macro_type = self._get_macro_type(record.macro)
+
+        self.skip_records.append(record)
+        self.records_by_type[(macro_type, record.skip_type)] += 1
+
+    def print_totals(self):
+        print(f"Total translated: {self.total_translated}")
+        print(f"Total skipped: {self.total_skipped}")
+
+        print(f"Object-like stats:")
+        print(f"  - Total translated: {self.total_translated_by_type(MacroType.OBJECT_LIKE)}")
+        print(f"    - Translated to enum: {self.records_by_type[(MacroType.OBJECT_LIKE,TranslationType.ENUM)]}")
+        print(f"    - Translated to enum: {self.records_by_type[(MacroType.OBJECT_LIKE,TranslationType.CONST_STATIC)]}")
+        print(f"  - Total skipped: {self.total_skipped_by_type(MacroType.OBJECT_LIKE)}")
+        print(f"    - Skipped due to function pointer type: {self.records_by_type[(MacroType.OBJECT_LIKE,SkipType.DEFINITION_HAS_FUNCTION_POINTER)]}")
+        print(f"    - Skipped due to DeclRefExpr: {self.records_by_type[(MacroType.OBJECT_LIKE,SkipType.BODY_CONTAINS_DECL_REF_EXPR)]}")
+        print(f"    - Untranslatable because enum size too small to represent ICE:"
+              f"{self.records_by_type[(MacroType.OBJECT_LIKE,SkipType.CANT_FIT_ICE_IN_ENUM_SIZE)]}")
+        print(f"    - Untranslatable contant expressions:"
+              f"{self.records_by_type[(MacroType.OBJECT_LIKE,SkipType.INVOCATION_REQUIRES_CONSTANT_EXPRESSION)]}")
+
+        print(f"Function-like stats:")
+        print(f"  - Total translated: {self.total_translated_by_type(MacroType.FUNCTION_LIKE)}")
+        print(f"    - Translated to void: {self.records_by_type[(MacroType.FUNCTION_LIKE,TranslationType.VOID)]}")
+        print(f"    - Translated to non-void: {self.records_by_type[(MacroType.FUNCTION_LIKE,TranslationType.NON_VOID)]}")
+        print(f"  - Total skipped: {self.total_skipped_by_type(MacroType.FUNCTION_LIKE)}")
+        print(f"    - Skipped due to function pointer type: {self.records_by_type[(MacroType.FUNCTION_LIKE,SkipType.DEFINITION_HAS_FUNCTION_POINTER)]}")
+        print(f"    - Skipped due to DeclRefExpr: {self.records_by_type[(MacroType.FUNCTION_LIKE,SkipType.BODY_CONTAINS_DECL_REF_EXPR)]}")
+
+
+
+
+
+

--- a/translationstats.py
+++ b/translationstats.py
@@ -109,10 +109,11 @@ class TranslationRecords:
     def output_csv(self, filename: str):
         with open(filename, 'w', newline='') as csvfile:
             writer = csv.writer(csvfile, quoting=csv.QUOTE_MINIMAL)
-            writer.writerow(["Macro", "Action", "Translation", "Type"])
+            writer.writerow(["Macro", "Macro Type", "Action", "Translation", "Action Type"])
 
             for translation_record in self.translation_records:
                 writer.writerow([translation_record.macro.Name,
+                                 self._get_macro_type(translation_record.macro),
                                  "Translated",
                                  translation_record.macro_translation,
                                  translation_record.translation_type]
@@ -120,6 +121,7 @@ class TranslationRecords:
 
             for skip_record in self.skip_records:
                 writer.writerow([skip_record.macro.Name,
+                                 self._get_macro_type(skip_record.macro),
                                  "Skipped",
                                  "",
                                  skip_record.skip_type]

--- a/translationstats.py
+++ b/translationstats.py
@@ -111,9 +111,16 @@ class TranslationRecords:
             writer = csv.writer(csvfile, quoting=csv.QUOTE_MINIMAL)
             writer.writerow(["Macro", "Action", "Translation", "Type"])
 
-            for record in self.translation_records:
-                writer.writerow([record.macro.Name, "Translated", record.macro_translation, record.translation_type])
+            for translation_record in self.translation_records:
+                writer.writerow([translation_record.macro.Name,
+                                 "Translated",
+                                 translation_record.macro_translation,
+                                 translation_record.translation_type]
+                                )
 
-            for record in self.skip_records:
-                writer.writerow([record.macro.Name, "Skipped", "", record.skip_type])
-
+            for skip_record in self.skip_records:
+                writer.writerow([skip_record.macro.Name,
+                                 "Skipped",
+                                 "",
+                                 skip_record.skip_type]
+                                )

--- a/translationstats.py
+++ b/translationstats.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, field
 from collections import Counter
-import sys
 import csv
 from macros import Macro
 from enum import Enum

--- a/translationstats.py
+++ b/translationstats.py
@@ -3,13 +3,10 @@ from collections import Counter
 import sys
 import csv
 from macros import Macro
+from enum import Enum
 
-# 3.10 compatibility
-if sys.version_info <= (3, 10):
-    from enum import Enum
-    class StrEnum(str, Enum): pass
-else:
-    from enum import StrEnum
+# 3.10 compatibility for StrEnum
+class StrEnum(str, Enum): pass 
 
 class MacroType(StrEnum):
     """

--- a/translationstats.py
+++ b/translationstats.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from collections import Counter
 import sys
+import csv
 from macros import Macro
 
 # 3.10 compatibility
@@ -108,9 +109,15 @@ class TranslationRecords:
         print(f"  - Total skipped: {self.total_skipped_by_type(MacroType.FUNCTION_LIKE)}")
         print(f"    - Skipped due to function pointer type: {self.records_by_type[(MacroType.FUNCTION_LIKE,SkipType.DEFINITION_HAS_FUNCTION_POINTER)]}")
         print(f"    - Skipped due to DeclRefExpr: {self.records_by_type[(MacroType.FUNCTION_LIKE,SkipType.BODY_CONTAINS_DECL_REF_EXPR)]}")
+    
+    def output_csv(self, filename: str):
+        with open(filename, 'w', newline='') as csvfile:
+            writer = csv.writer(csvfile, quoting=csv.QUOTE_MINIMAL)
+            writer.writerow(["Macro", "Action", "Translation", "Type"])
 
+            for record in self.translation_records:
+                writer.writerow([record.macro.Name, "Translated", record.macro_translation, record.translation_type])
 
-
-
-
+            for record in self.skip_records:
+                writer.writerow([record.macro.Name, "Skipped", "", record.skip_type])
 


### PR DESCRIPTION
Add translation statistics and CSV output for translations to Maki.

First, in `MacroTranslator`, we now return `MacroRecord`s (either a `SkipRecord` or `TranslationRecord`) which provides information on the reason a macro was skipped, or the type of translation that occurred. 

For each translation/skip record we receive, we add it to the `TranslationStats` class which holds a list of `SkipRecord`s and `TranslationRecords`, along with a Counter that can be indexed by tuples of the macro type and skip reason/translation type.

`TranslationStats.print_totals` is called to print a summary message of the total amount of translations/skips, these amounts per macro type, and the amount of macros fulfilling a translation type or skip reason, i.e
```
Total translated: 371
Total skipped: 1
Object-like stats:
  - Total translated: 347
    - Translated to enum: 145
    - Translated to enum: 202
  - Total skipped: 1
    - Skipped due to function pointer type: 0
    - Skipped due to DeclRefExpr: 0
    - Untranslatable because enum size too small to represent ICE:1
    - Untranslatable contant expressions:0
Function-like stats:
  - Total translated: 24
    - Translated to void: 1
    - Translated to non-void: 23
  - Total skipped: 0
    - Skipped due to function pointer type: 0
    - Skipped due to DeclRefExpr: 0
 ```


`TranslationStats.output_csv` supports outputting information in the format of [macro name, macro type, "Skipped" or "Translated", translation if any, action type]. This will be called if `--output-csv` is set with a file location.
Example CSV:
[nvim.csv](https://github.com/user-attachments/files/16300796/a.csv)

