### PR TITLE
Fix void return type logic

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -269,6 +269,14 @@ class Invocation:
     def SatisfiesALanguageSpecificProperty(self) -> bool:
         return self.MustUseMetaprogrammingToTransform
         
+    @property
+    def IsExpression(self) -> bool:
+        return self.ASTKind == 'Expr'
+
+    @property
+    def IsStatement(self) -> bool:
+        return self.ASTKind == 'Stmt'
+
     def CanBeTurnedIntoEnumWithIntSize(self, int_size: IntSize) -> bool:
         return self.CanBeTurnedIntoEnum and \
         (self.IsICERepresentableByInt32 if int_size == IntSize.Int32

--- a/macrotranslator.py
+++ b/macrotranslator.py
@@ -84,8 +84,8 @@ class MacroTranslator:
     def translate_function_like_macro(self, macro: Macro, invocations: set[Invocation]) -> TranslationRecord:
         invocation = next(iter(invocations))
 
-        # Determine if we return or not - can't return a statement
-        is_void = invocation.IsExpansionTypeVoid and invocation.IsStatement
+        # Determine if we return or not
+        is_void = invocation.IsExpansionTypeVoid or invocation.IsStatement
         returnStatement = "return" if not is_void else ""
 
         translation_type = TranslationType.NON_VOID if not is_void else TranslationType.VOID

--- a/macrotranslator.py
+++ b/macrotranslator.py
@@ -82,13 +82,14 @@ class MacroTranslator:
         return None
 
     def translate_function_like_macro(self, macro: Macro, invocations: set[Invocation]) -> TranslationRecord:
-        # Make sure we don't return for void functions,
-        # but do return for void * and anything else
         invocation = next(iter(invocations))
-        is_void = invocation.IsExpansionTypeVoid
+
+        # Determine if we return or not - can't return a statement
+        is_void = invocation.IsExpansionTypeVoid and invocation.IsStatement
+        returnStatement = "return" if not is_void else ""
+
         translation_type = TranslationType.NON_VOID if not is_void else TranslationType.VOID
 
-        returnStatement = "return" if not is_void else ""
         translation = f"static inline {invocation.TypeSignature} {{ {returnStatement} {macro.Body}; }}"
         return TranslationRecord(macro, translation, translation_type)
 


### PR DESCRIPTION
Previous return logic by just checking if expansion type was void is incorrect. We need to also check if we are a statement (i.e not an expression with some value) to determine if we return or not.