### PR TITLE
Split CompileCommands with multiple source files in it's arguments to multiple CompileCommands

### DIFF
--- a/run_maki_on_compile_commands.py
+++ b/run_maki_on_compile_commands.py
@@ -73,6 +73,9 @@ def run_maki_on_compile_command(cc: CompileCommand, maki_so_path: str) -> list[d
         logger.exception(f"Error running maki with args {args} on {cc.file}: {e}")
         return []
 
+def is_source_file(arg: str) -> bool:
+    return arg.endswith('.c')
+
 def split_compile_commands_by_src_file(cc: CompileCommand) -> list[CompileCommand]:
     """
     Take a compile command and split it into multiple compile commands
@@ -80,12 +83,12 @@ def split_compile_commands_by_src_file(cc: CompileCommand) -> list[CompileComman
     """
 
     # Filter out all source files from the arguments
-    arguments_no_src_files = [arg for arg in cc.arguments if not arg.endswith('.c')]
+    arguments_no_src_files = [arg for arg in cc.arguments if not is_source_file(arg)]
 
     # Return a list of CompileCommands for each source file in the original compile command args
     return [
         CompileCommand(directory=cc.directory, arguments=arguments_no_src_files, file=src_file)
-        for src_file in cc.arguments if src_file.endswith('.c')
+        for src_file in cc.arguments if is_source_file(src_file)
     ]
     
 

--- a/run_maki_on_compile_commands.py
+++ b/run_maki_on_compile_commands.py
@@ -38,13 +38,13 @@ class CompileCommand:
         )
 
 
-def run_maki_on_compile_command(cc: CompileCommand, maki_so_path: str) -> dict[str, Any]:
+def run_maki_on_compile_command(cc: CompileCommand, maki_so_path: str) -> list[dict[str, Any]]:
 
-    args = cc.arguments
     # pass cpp2c plugin shared library file
-    args[0] = "/usr/bin/clang-17"
+    args = cc.arguments
+    args[0] = "clang-17"
     args.insert(1, f'-fplugin={maki_so_path}')
-    args[-1] = cc.file
+    args.append(cc.file)
     # at the very end, specify that we are only doing syntactic analysis
     # so as to not waste time compiling
     args.append('-fsyntax-only')
@@ -71,8 +71,23 @@ def run_maki_on_compile_command(cc: CompileCommand, maki_so_path: str) -> dict[s
         return json.loads(process.stdout.decode())
     except subprocess.CalledProcessError as e:
         logger.exception(f"Error running maki with args {args} on {cc.file}: {e}")
-        return {}
+        return []
 
+def split_compile_commands_by_src_file(cc: CompileCommand) -> list[CompileCommand]:
+    """
+    Take a compile command and split it into multiple compile commands
+    for each source file in the compile command
+    """
+
+    # Filter out all source files from the arguments
+    arguments_no_src_files = [arg for arg in cc.arguments if not arg.endswith('.c')]
+
+    # Return a list of CompileCommands for each source file in the original compile command args
+    return [
+        CompileCommand(directory=cc.directory, arguments=arguments_no_src_files, file=src_file)
+        for src_file in cc.arguments if src_file.endswith('.c')
+    ]
+    
 
 def main():
     ap = argparse.ArgumentParser()
@@ -108,13 +123,16 @@ def main():
 
     compile_commands = [CompileCommand.from_json(cc) for cc in compile_commands]
 
+    # Split compile commands into multiple compile commands for each source file
+    split_compile_commands = [split_cc for cc in compile_commands 
+                           for split_cc in split_compile_commands_by_src_file(cc)]
 
     # Run maki on each compile command threaded
     with concurrent.futures.ProcessPoolExecutor(max_workers=num_jobs) as executor:
         results = list(
             executor.map(
                 partial(run_maki_on_compile_command, maki_so_path=plugin_path),
-                compile_commands
+                split_compile_commands
             )
         )
 


### PR DESCRIPTION
Some programs like SQLite have compile commands that contain multiple source files within their arguments to link them together with gcc/clang automatically, i.e `gcc shell.c sqlite3.c -o sqlite3`. 

This will call Maki with multiple source files which will lead to two different JSON arrays being output with a single invocation of Maki, which causes this script to crash as it expects a single array per file.

To fix this we preprocess each `CompileCommand` by stripping out all source files from it's arguments (anything ending with .c). Then we create a list of new `CompileCommands` for every source file found in the original arguments, where the file attribute is the individual file and the arguments attribute will be the stripped arguments list.

This way, we can guarantee that each file has the flags it needs to compile, and each command ran will be only on a single file and it's output entry will be associated with the correct file.

Also, fix some incorrect typehints (run_maki_on_compile_command returns a list of JSON entries) and make our args use "clang-17" and not "/usr/bin/clang-17" to respect PATH.