### PR TITLE
Track non-technical macro translation skip reasons

### DIFF
--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -2,7 +2,6 @@ import json
 from typing import Set, Any
 import logging
 from collections import Counter
-import re
 
 from macros import Macro, MacroMap, PreprocessorData, Invocation
 from predicates.argument_altering import aa_invocation
@@ -49,7 +48,7 @@ def filter_definitions(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
     return filtered_entries
 
-def get_interface_equivalent_preprocessordata(results_file: str) -> PreprocessorData:
+def get_tlna_src_preprocessordata(results_file: str) -> PreprocessorData:
 
     with open(results_file) as fp:
         entries = json.load(fp)
@@ -114,11 +113,5 @@ def get_interface_equivalent_preprocessordata(results_file: str) -> Preprocessor
 
     # ie_pd only records preprocessor data about interface-equivalent
     # macros
-    ie_pd = PreprocessorData(
-        {m: is_ for m, is_ in tlna_src_pd.mm.items()
-         if ie_def(m, tlna_src_pd)},
-        tlna_src_pd.inspected_macro_names,
-        tlna_src_pd.local_includes
-    )
 
-    return ie_pd
+    return tlna_src_pd

--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -1,36 +1,11 @@
 import json
-from typing import Set, Any
+from typing import Any
 import logging
 from collections import Counter
 
-from macros import Macro, MacroMap, PreprocessorData, Invocation
-from predicates.argument_altering import aa_invocation
-from predicates.call_site_context_altering import csca_invocation
-from predicates.declaration_altering import da_invocation
-from predicates.interface_equivalent import ie_def
-from predicates.metaprogramming import mp_invocation
-from predicates.thunkizing import thunkizing_invocation
+from macros import Macro, PreprocessorData, Invocation
 
 logger = logging.getLogger(__name__)
-
-
-def easy_to_transform_invocation(i: Invocation,
-                                 pd: PreprocessorData,
-                                 ie_invocations: Set[Invocation]):
-    return ((i in ie_invocations) or
-            ((aa_invocation(i, pd) or da_invocation(i, pd)) and
-             (not csca_invocation(i, pd)) and
-             (not thunkizing_invocation(i, pd)) and
-             (not mp_invocation(i, pd))))
-
-
-def easy_to_transform_definition(m: Macro,
-                                 pd: PreprocessorData,
-                                 ie_invocations: Set[Invocation]):
-    return all(
-        easy_to_transform_invocation(i, pd, ie_invocations)
-        for i in pd.mm[m]
-    )
 
 def filter_definitions(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
     # Count the number of definitions with a given name

--- a/analyze_transformations.py
+++ b/analyze_transformations.py
@@ -111,7 +111,5 @@ def get_tlna_src_preprocessordata(results_file: str) -> PreprocessorData:
         src_pd.local_includes
     )
 
-    # ie_pd only records preprocessor data about interface-equivalent
-    # macros
 
     return tlna_src_pd

--- a/emit_translations.py
+++ b/emit_translations.py
@@ -5,7 +5,7 @@ import logging
 import os
 import pathlib
 
-from analyze_transformations import get_interface_equivalent_preprocessordata
+from analyze_transformations import get_tlna_src_preprocessordata
 from macros import Macro
 from macrotranslator import MacroTranslator
 from translationconfig import TranslationConfig, IntSize
@@ -104,9 +104,9 @@ def main():
     log_level = logging.INFO if args.verbose else logging.WARNING
     logging.basicConfig(level=log_level)
 
-    ie_pd = get_interface_equivalent_preprocessordata(maki_analysis_path)
+    tlna_src_pd = get_tlna_src_preprocessordata(maki_analysis_path)
     translator = MacroTranslator(translation_config)
-    translations = translator.generate_macro_translations(ie_pd.mm)
+    translations = translator.generate_macro_translations(tlna_src_pd)
 
     translate_src_files(input_src_dir, output_translation_dir, translations)
 

--- a/macros.py
+++ b/macros.py
@@ -114,6 +114,7 @@ class Invocation:
     @property
     def HasSemanticData(self) -> bool:
         return all([
+            # TODO: Check that we don't end with a compound statement
             self.IsTopLevelNonArgument,
             not self.IsAnyArgumentNeverExpanded,
             self.IsAligned,

--- a/macros.py
+++ b/macros.py
@@ -202,10 +202,7 @@ class Invocation:
             return True
 
         assert self.HasSemanticData
-        return any([
-            self.IsExpansionControlFlowStmt,
-            self.IsAnyArgumentConditionallyEvaluated
-        ])
+        return self.IsAnyArgumentConditionallyEvaluated
 
     @property
     def MustCreateThunksToTransform(self) -> bool:
@@ -220,7 +217,9 @@ class Invocation:
                 (self.HasSemanticData and
                  self.IsFunctionLike and
                  self.CanBeTurnedIntoFunction and
-                 self.IsAnyArgumentNotAnExpression))
+                 self.IsAnyArgumentNotAnExpression) or
+                self.IsExpansionControlFlowStmt or
+                self.IsNamePresentInCPPConditional)
 
     @property
     def SatisfiesASyntacticProperty(self) -> bool:
@@ -281,6 +280,21 @@ class Invocation:
         return self.CanBeTurnedIntoEnum and \
         (self.IsICERepresentableByInt32 if int_size == IntSize.Int32
          else self.IsICERepresentableByInt16)
+
+    @property
+    def IsValidStatementKind(self) -> bool:
+        if self.IsObjectLike:
+            return self.IsExpression
+        else:
+            return self.IsExpression or self.IsStatement
+
+    @property
+    def IsCalledByName(self) -> bool:
+        return any([
+            self.MustAlterCallSiteToTransform,
+            self.MustCreateThunksToTransform,
+            self.MustAlterArgumentsOrReturnTypeToTransform
+            ])
 
 
 MacroMap = dict[Macro, Set[Invocation]]

--- a/macros.py
+++ b/macros.py
@@ -44,6 +44,7 @@ class Invocation:
     DoesBodyReferenceMacroDefinedAfterMacro: bool
     DoesBodyReferenceDeclDeclaredAfterMacro: bool
     DoesBodyContainDeclRefExpr: bool
+    DoesBodyEndWithCompoundStmt: bool
     DoesSubexpressionExpandedFromBodyHaveLocalType: bool
     DoesSubexpressionExpandedFromBodyHaveTypeDefinedAfterMacro: bool
 
@@ -76,6 +77,7 @@ class Invocation:
 
     IsInvokedWhereModifiableValueRequired: bool
     IsInvokedWhereAddressableValueRequired: bool
+    IsAnyArgumentExpandedWhereConstExprRequired: bool
     IsInvokedWhereICERequired: bool
     IsInvokedWhereConstantExpressionRequired: bool
 
@@ -135,11 +137,18 @@ class Invocation:
             self.ASTKind == 'Expr',
             # Variables cannot contain DeclRefExprs
             not self.DoesBodyContainDeclRefExpr,
-            not self.DoesAnyArgumentContainDeclRefExpr,
             # Variables cannot be invoked where ICEs are required
             not self.IsInvokedWhereICERequired,
             # Variables cannot have the void type
             not self.IsExpansionTypeVoid
+        ])
+
+    @property
+    def IsExpansionConstantExpression(self) -> bool:
+        return all([
+            self.ASTKind == 'Expr',
+            # Variables cannot contain DeclRefExprs
+            not self.DoesBodyContainDeclRefExpr,
         ])
 
     @property
@@ -191,9 +200,6 @@ class Invocation:
             self.IsExpansionTypeAnonymous,
             self.IsExpansionTypeLocalType,
             self.IsExpansionTypeDefinedAfterMacro,
-            self.IsAnyArgumentTypeAnonymous,
-            self.IsAnyArgumentTypeLocalType,
-            self.IsAnyArgumentTypeDefinedAfterMacro,
             self.ASTKind == 'TypeLoc'
         ])
 
@@ -292,9 +298,16 @@ class Invocation:
     @property
     def IsCalledByName(self) -> bool:
         return any([
-            self.MustAlterCallSiteToTransform,
-            self.MustCreateThunksToTransform,
-            self.MustAlterArgumentsOrReturnTypeToTransform
+            self.IsAnyArgumentConditionallyEvaluated,
+            self.DoesAnyArgumentHaveSideEffects,
+            ])
+
+    @property
+    def ArgumentsCaptureEnvironment(self) -> bool:
+        return any([
+            self.IsAnyArgumentTypeAnonymous,
+            self.IsAnyArgumentTypeLocalType,
+            self.IsAnyArgumentTypeDefinedAfterMacro,
             ])
 
 

--- a/macrotranslator.py
+++ b/macrotranslator.py
@@ -4,7 +4,7 @@ import logging
 import re
 from translationstats import TranslationRecord, TranslationRecords, SkipRecord, MacroRecord
 from translationstats import TranslationTarget
-from translationstats import SkipType
+from translationstats import TechnicalSkip
 import predicates.interface_equivalent
 from predicates.interface_equivalent import ie_def, IEResult, TranslationTarget
 
@@ -55,9 +55,9 @@ class MacroTranslator:
             case TranslationTarget.ENUM:
                 return self.translate_macro_to_enum(macro, invocations)
             case None:
-                return SkipRecord(macro, SkipType.NOT_INTERFACE_EQUIVALENT, ie_result)
+                return SkipRecord(macro, ie_result)
 
-    def should_skip_due_to_technical_limitations(self, macro: Macro, invocations: set[Invocation]) -> SkipType | None:
+    def should_skip_due_to_technical_limitations(self, macro: Macro, invocations: set[Invocation]) -> TechnicalSkip | None:
         """
         Skips are due to technical limitations of Maki and MerC and not
         due to irreconcilable differences in macro and C semantics.
@@ -78,7 +78,7 @@ class MacroTranslator:
         # TODO(Joey): Implement a way to translate these
         if invocation_has_function_type:
             logger.debug(f"Skipping {macro.Name} as it has a function pointer type")
-            return SkipType.DEFINITION_HAS_FUNCTION_POINTER
+            return TechnicalSkip.DEFINITION_HAS_FUNCTION_POINTER
 
         # If body contains a DeclRefExpr and is in a header file, skip
         # TODO(Joey/Brent): Find better way on Maki side to handle this
@@ -87,7 +87,7 @@ class MacroTranslator:
         invocation_has_decl_ref_expr = invocation.DoesBodyContainDeclRefExpr
         if invocation_has_decl_ref_expr and invocation.DefinitionLocationFilename.endswith(".h"):
             logger.debug(f"Skipping {macro.Name} as it contains a DeclRefExpr")
-            return SkipType.BODY_CONTAINS_DECL_REF_EXPR
+            return TechnicalSkip.BODY_CONTAINS_DECL_REF_EXPR
 
         return None
 

--- a/macrotranslator.py
+++ b/macrotranslator.py
@@ -1,13 +1,10 @@
-from macros import MacroMap, Macro, Invocation, PreprocessorData
-from translationconfig import TranslationConfig
 import logging
-import re
-from translationstats import TranslationRecord, TranslationRecords, SkipRecord, MacroRecord
-from translationstats import TranslationTarget
-from translationstats import TechnicalSkip
-import predicates.interface_equivalent
-from predicates.interface_equivalent import ie_def, IEResult, TranslationTarget
 
+from macros import Macro, Invocation, PreprocessorData
+from predicates.interface_equivalent import ie_def, TranslationTarget
+from translationconfig import TranslationConfig
+from translationstats import TechnicalSkip
+from translationstats import TranslationRecord, TranslationRecords, SkipRecord, MacroRecord
 
 logger = logging.getLogger(__name__)
 

--- a/predicates/interface_equivalent.py
+++ b/predicates/interface_equivalent.py
@@ -69,6 +69,7 @@ GLOBAL_CONDITIONS = [
 VARIABLE_CONDITIONS = [
     Condition(lambda i, pd: not i.IsInvokedWhereConstantExpressionRequired, IEResult.INVOKED_WHERE_CONSTANT_EXPRESSION_REQUIRED),     
     Condition(lambda i, pd: i.IsExpansionConstantExpression, IEResult.EXPANSION_NOT_CONSTANT_EXPRESSION),
+    Condition(lambda i, pd: not i.IsExpansionTypeVoid, IEResult.EXPANSION_TYPE_VOID),
 ]
 
 ENUM_CONDITIONS = [

--- a/predicates/interface_equivalent.py
+++ b/predicates/interface_equivalent.py
@@ -7,7 +7,7 @@ class IEResult(Enum):
     MACRO_NEVER_EXPANDED = auto()
     POLYMORPHIC = auto()
     NON_GLOBAL_SCOPE = auto()
-    LACKS_SEMANTIC_DATA = auto()
+    SYNTACTICALLY_INVALID_PROPERTY = auto()
     CANNOT_TRANSFORM = auto()
 
     USE_METAPROGRAMMING = auto()
@@ -24,7 +24,7 @@ def ie_def(m: Macro, pd: PreprocessorData) -> IEResult:
     assert all([i.IsTopLevelNonArgument for i in is_])
     # We must have semantic data for all invocations
     if not all([i.HasSemanticData for i in is_]):
-        return IEResult.LACKS_SEMANTIC_DATA
+        return IEResult.SYNTACTICALLY_INVALID_PROPERTY
     # The macro must be expanded at least once
     if len(is_) == 0:
         return IEResult.MACRO_NEVER_EXPANDED
@@ -37,7 +37,7 @@ def ie_def(m: Macro, pd: PreprocessorData) -> IEResult:
 
     def check_conditions(i: Invocation):
         CONDITIONS = [
-                (i.HasSemanticData, IEResult.LACKS_SEMANTIC_DATA), 
+                (i.HasSemanticData, IEResult.SYNTACTICALLY_INVALID_PROPERTY), 
 
                 (not i.IsInvokedWhereAddressableValueRequired and not i.IsInvokedWhereModifiableValueRequired, IEResult.ADDRESSABLE_VALUE_REQUIRED),
 

--- a/predicates/interface_equivalent.py
+++ b/predicates/interface_equivalent.py
@@ -10,11 +10,11 @@ class IEResult(Enum):
     LACKS_SEMANTIC_DATA = auto()
     CANNOT_TRANSFORM = auto()
 
-    MUST_USE_METAPROGRAMMING = auto()
+    USE_METAPROGRAMMING = auto()
     THUNKIZING = auto()
     CALLSITE_CONTEXT_ALTERING = auto()
-    CALLING_CONVENTION_ADAPTING = auto()
-    SCOPE_ADAPTING = auto()
+    CALLED_BY_NAME = auto()
+    DYNAMICALLY_SCOPED = auto()
 
 def ie_def(m: Macro, pd: PreprocessorData) -> IEResult:
     is_ = pd.mm[m]
@@ -33,7 +33,6 @@ def ie_def(m: Macro, pd: PreprocessorData) -> IEResult:
     if not m.IsDefinedAtGlobalScope:
         return IEResult.NOT_DEFINED_AT_GLOBAL_SCOPE
 
-                # Valid for analysis
     def check_conditions(i: Invocation):
         CONDITIONS = [
                 # Valid for analysis
@@ -41,17 +40,17 @@ def ie_def(m: Macro, pd: PreprocessorData) -> IEResult:
                 # Can be turn into an enum or variable
                 (i.CanBeTurnedIntoEnumOrVariable if m.IsObjectLike else i.CanBeTurnedIntoFunction, IEResult.CANNOT_TRANSFORM),
                 # Argument-altering
-                (not i.MustAlterArgumentsOrReturnTypeToTransform, IEResult.CALLING_CONVENTION_ADAPTING),
+                (not i.MustAlterArgumentsOrReturnTypeToTransform, IEResult.CALLED_BY_NAME),
                 # Declaration-altering
-                (i.DefinitionLocationFilename not in pd.local_includes, IEResult.SCOPE_ADAPTING),
-                (i.Name not in pd.inspected_macro_names, IEResult.SCOPE_ADAPTING),
-                (not i.IsNamePresentInCPPConditional, IEResult.SCOPE_ADAPTING),
-                (not i.MustAlterDeclarationsToTransform, IEResult.SCOPE_ADAPTING),
+                (i.DefinitionLocationFilename not in pd.local_includes, IEResult.DYNAMICALLY_SCOPED),
+                (i.Name not in pd.inspected_macro_names, IEResult.DYNAMICALLY_SCOPED),
+                (not i.IsNamePresentInCPPConditional, IEResult.DYNAMICALLY_SCOPED),
+                (not i.MustAlterDeclarationsToTransform, IEResult.DYNAMICALLY_SCOPED),
                 # Call-site-context-altering
                 (not i.MustAlterCallSiteToTransform, IEResult.CALLSITE_CONTEXT_ALTERING),
                 # Thunkizing
                 (not i.MustCreateThunksToTransform, IEResult.THUNKIZING),
-                (not i.MustUseMetaprogrammingToTransform, IEResult.MUST_USE_METAPROGRAMMING)
+                (not i.MustUseMetaprogrammingToTransform, IEResult.USE_METAPROGRAMMING)
                 ]
         for condition, result in CONDITIONS:
             if not condition:

--- a/predicates/interface_equivalent.py
+++ b/predicates/interface_equivalent.py
@@ -1,5 +1,9 @@
+from collections.abc import Callable
+from dataclasses import dataclass
 from macros import Invocation, Macro, PreprocessorData
 from enum import Enum, auto
+
+from translationconfig import TranslationConfig
 
 class IEResult(Enum):
     VALID = auto()
@@ -10,58 +14,153 @@ class IEResult(Enum):
     SYNTACTICALLY_INVALID_PROPERTY = auto()
     CANNOT_TRANSFORM = auto()
 
+    INVOKED_WHERE_ICE_REQUIRED_AND_GREATER_THAN_INT_SIZE = auto()
+    INVOKED_WHERE_CONSTANT_EXPRESSION_REQUIRED = auto()
+    EXPANSION_NOT_CONSTANT_EXPRESSION = auto()
+    EXPANSION_NOT_ICE = auto()
+    EXPANSION_TYPE_VOID = auto()
+    EXPANSION_TYPE_NON_VOID = auto()
+
     USE_METAPROGRAMMING = auto()
     CALLED_BY_NAME = auto()
     CALLSITE_CONTEXT_ALTERING = auto()
-    DYNAMICALLY_SCOPED = auto()
+    CAPTURES_ENVIRONMENT = auto()
     ADDRESSABLE_VALUE_REQUIRED = auto()
     INVALID_STATEMENT_KIND = auto()
 
+    ARGUMENT_ADDRESSABLE_VALUE_REQUIRED = auto()
+    ARGUMENT_TYPE_VOID = auto()
+    ARGUMENT_TYPE_NOT_EXPRESSION = auto()
+    ARGUMENT_INVOKED_WHERE_CONSTANT_EXPRESSION_REQUIRED = auto()
+    ARGUMENT_CAPTURES_ENVIRONMENT = auto()
+    ARGUMENT_CALLED_BY_NAME = auto()
 
-def ie_def(m: Macro, pd: PreprocessorData) -> IEResult:
+class TranslationTarget(Enum):
+    GLOBAL_VARIABLE = auto()
+    ENUM = auto()
+    NON_VOID_FUNCTION = auto()
+    VOID_FUNCTION = auto()
+
+@dataclass
+class Condition:
+    check: Callable[[Invocation, PreprocessorData], bool]
+    result: IEResult
+
+def check_conditions(invocations: set[Invocation], pd: PreprocessorData, conditions: list[Condition]) -> IEResult:
+    for invocation in invocations:
+        for condition in conditions:
+            if not condition.check(invocation, pd):
+                return condition.result
+    return IEResult.VALID
+
+GLOBAL_CONDITIONS = [
+        Condition(lambda i, pd: i.HasSemanticData, IEResult.SYNTACTICALLY_INVALID_PROPERTY), 
+
+        Condition(lambda i, pd: not i.IsInvokedWhereAddressableValueRequired and not i.IsInvokedWhereModifiableValueRequired, IEResult.ADDRESSABLE_VALUE_REQUIRED),
+
+        Condition(lambda i, pd: i.DefinitionLocationFilename not in pd.local_includes, IEResult.CAPTURES_ENVIRONMENT),
+        Condition(lambda i, pd: not i.MustAlterDeclarationsToTransform, IEResult.CAPTURES_ENVIRONMENT),
+
+
+        Condition(lambda i, pd: not i.MustUseMetaprogrammingToTransform, IEResult.USE_METAPROGRAMMING),
+        Condition(lambda i, pd: i.Name not in pd.inspected_macro_names, IEResult.USE_METAPROGRAMMING),
+]
+
+VARIABLE_CONDITIONS = [
+    Condition(lambda i, pd: not i.IsInvokedWhereConstantExpressionRequired, IEResult.INVOKED_WHERE_CONSTANT_EXPRESSION_REQUIRED),     
+    Condition(lambda i, pd: i.IsExpansionConstantExpression, IEResult.EXPANSION_NOT_CONSTANT_EXPRESSION),
+]
+
+ENUM_CONDITIONS = [
+    Condition(lambda i, pd: i.IsExpansionICE, IEResult.EXPANSION_NOT_ICE),
+]
+
+NON_VOID_CONDITIONS = [
+    Condition(lambda i, pd: not i.IsInvokedWhereConstantExpressionRequired, IEResult.INVOKED_WHERE_CONSTANT_EXPRESSION_REQUIRED),     
+    Condition(lambda i, pd: not i.IsExpansionTypeVoid, IEResult.EXPANSION_TYPE_VOID),
+    Condition(lambda i, pd: i.IsExpression, IEResult.INVALID_STATEMENT_KIND),
+]
+
+VOID_CONDITIONS = [
+    Condition(lambda i, pd: not i.IsInvokedWhereConstantExpressionRequired, IEResult.INVOKED_WHERE_CONSTANT_EXPRESSION_REQUIRED),     
+    Condition(lambda i, pd: i.IsExpansionTypeVoid, IEResult.EXPANSION_TYPE_NON_VOID),
+    Condition(lambda i, pd: i.IsExpression or i.IsStatement, IEResult.INVALID_STATEMENT_KIND),
+]
+
+ARGUMENT_CONDITIONS = [
+    Condition(lambda i, pd: not i.IsCalledByName, IEResult.CALLED_BY_NAME),
+    Condition(lambda i, pd: not i.IsAnyArgumentExpandedWhereConstExprRequired, IEResult.ARGUMENT_INVOKED_WHERE_CONSTANT_EXPRESSION_REQUIRED),
+    Condition(lambda i, pd: not i.IsAnyArgumentTypeVoid, IEResult.ARGUMENT_TYPE_VOID),
+    Condition(lambda i, pd: not (i.IsAnyArgumentExpandedWhereModifiableValueRequired or i.IsAnyArgumentExpandedWhereAddressableValueRequired), IEResult.ARGUMENT_ADDRESSABLE_VALUE_REQUIRED),
+    Condition(lambda i, pd: not i.IsAnyArgumentNotAnExpression, IEResult.ARGUMENT_TYPE_NOT_EXPRESSION),
+]
+
+
+
+def ie_def(m: Macro, pd: PreprocessorData, translation_config: TranslationConfig) -> tuple[IEResult, TranslationTarget | None]:
     is_ = pd.mm[m]
     # We only analyze top-level non-argument invocations
     assert all([i.IsTopLevelNonArgument for i in is_])
     # We must have semantic data for all invocations
     if not all([i.HasSemanticData for i in is_]):
-        return IEResult.SYNTACTICALLY_INVALID_PROPERTY
+        return IEResult.SYNTACTICALLY_INVALID_PROPERTY, None
     # The macro must be expanded at least once
     if len(is_) == 0:
-        return IEResult.MACRO_NEVER_EXPANDED
+        return IEResult.MACRO_NEVER_EXPANDED, None
     # All invocations must have the same type signature
     if len(set([i.TypeSignature for i in is_])) != 1:
-        return IEResult.POLYMORPHIC
+        return IEResult.POLYMORPHIC, None
     # The macro must be defined at global scope
     if not m.IsDefinedAtGlobalScope:
-        return IEResult.NON_GLOBAL_SCOPE
-
-    def check_conditions(i: Invocation):
-        CONDITIONS = [
-                (i.HasSemanticData, IEResult.SYNTACTICALLY_INVALID_PROPERTY), 
-
-                (not i.IsInvokedWhereAddressableValueRequired and not i.IsInvokedWhereModifiableValueRequired, IEResult.ADDRESSABLE_VALUE_REQUIRED),
-
-                (i.IsValidStatementKind, IEResult.INVALID_STATEMENT_KIND),
-
-                (i.CanBeTurnedIntoEnumOrVariable if m.IsObjectLike else i.CanBeTurnedIntoFunction, IEResult.CANNOT_TRANSFORM),
-
-                (i.DefinitionLocationFilename not in pd.local_includes, IEResult.DYNAMICALLY_SCOPED),
-                (not i.MustAlterDeclarationsToTransform, IEResult.DYNAMICALLY_SCOPED),
-
-                (not i.IsCalledByName, IEResult.CALLED_BY_NAME),
-
-                (not i.MustUseMetaprogrammingToTransform, IEResult.USE_METAPROGRAMMING),
-                (i.Name not in pd.inspected_macro_names, IEResult.USE_METAPROGRAMMING),
-                ]
-        for condition, result in CONDITIONS:
-            if not condition:
-                return result
-        return None
-
-    for i in is_:
-        result = check_conditions(i)
-        if result:
-            return result
-
-    return IEResult.VALID
+        return IEResult.NON_GLOBAL_SCOPE, None
     
+    global_condition_check = check_conditions(invocations=is_,
+                                              pd=pd,
+                                              conditions=GLOBAL_CONDITIONS)
+    if global_condition_check != IEResult.VALID:
+        if not m.IsObjectLike:
+            print(f"Function macro {m.Name} is not global {global_condition_check}")
+
+        return global_condition_check, None
+
+    if m.IsObjectLike:
+        variable_condition_check = check_conditions(invocations=is_,
+                                                    pd=pd,
+                                                    conditions=VARIABLE_CONDITIONS)
+        enum_condition_check = check_conditions(invocations=is_,
+                                                pd=pd,
+                                                conditions=ENUM_CONDITIONS)
+
+        if variable_condition_check == IEResult.VALID:
+            return IEResult.VALID, TranslationTarget.GLOBAL_VARIABLE
+        elif enum_condition_check == IEResult.VALID:
+            if all([i.CanBeTurnedIntoEnumWithIntSize(translation_config.int_size) for i in is_]):
+                return enum_condition_check, TranslationTarget.ENUM
+            else:
+                return IEResult.INVOKED_WHERE_ICE_REQUIRED_AND_GREATER_THAN_INT_SIZE, None
+        else:
+            return enum_condition_check, None
+
+        
+    else:
+        argument_condition_check = check_conditions(invocations=is_,
+                                                    pd=pd,
+                                                    conditions=ARGUMENT_CONDITIONS)
+
+        if argument_condition_check != IEResult.VALID:
+            return argument_condition_check, None
+
+        non_void_condition_check = check_conditions(invocations=is_,
+                                                    pd=pd,
+                                                    conditions=NON_VOID_CONDITIONS)
+        void_condition_check = check_conditions(invocations=is_,
+                                                pd=pd,
+                                                conditions=VOID_CONDITIONS)
+
+        if non_void_condition_check == IEResult.VALID:
+            return non_void_condition_check, TranslationTarget.NON_VOID_FUNCTION
+        elif void_condition_check == IEResult.VALID:
+            return void_condition_check, TranslationTarget.VOID_FUNCTION
+        else:
+            print(f"Function macro {m.Name} is neither void nor non-void {non_void_condition_check} {void_condition_check}")
+            return void_condition_check, None

--- a/predicates/interface_equivalent.py
+++ b/predicates/interface_equivalent.py
@@ -12,10 +12,10 @@ class IEResult(Enum):
     POLYMORPHIC = auto()
     NON_GLOBAL_SCOPE = auto()
     SYNTACTICALLY_INVALID_PROPERTY = auto()
-    CANNOT_TRANSFORM = auto()
 
     INVOKED_WHERE_ICE_REQUIRED_AND_GREATER_THAN_INT_SIZE = auto()
     INVOKED_WHERE_CONSTANT_EXPRESSION_REQUIRED = auto()
+
     EXPANSION_NOT_CONSTANT_EXPRESSION = auto()
     EXPANSION_NOT_ICE = auto()
     EXPANSION_TYPE_VOID = auto()
@@ -23,7 +23,6 @@ class IEResult(Enum):
 
     USE_METAPROGRAMMING = auto()
     CALLED_BY_NAME = auto()
-    CALLSITE_CONTEXT_ALTERING = auto()
     CAPTURES_ENVIRONMENT = auto()
     ADDRESSABLE_VALUE_REQUIRED = auto()
     INVALID_STATEMENT_KIND = auto()
@@ -55,6 +54,7 @@ def check_conditions(invocations: set[Invocation], pd: PreprocessorData, conditi
 
 GLOBAL_CONDITIONS = [
         Condition(lambda i, pd: i.HasSemanticData, IEResult.SYNTACTICALLY_INVALID_PROPERTY), 
+        Condition(lambda i, pd: not i.DoesBodyEndWithCompoundStmt, IEResult.SYNTACTICALLY_INVALID_PROPERTY),
 
         Condition(lambda i, pd: not i.IsInvokedWhereAddressableValueRequired and not i.IsInvokedWhereModifiableValueRequired, IEResult.ADDRESSABLE_VALUE_REQUIRED),
 

--- a/predicates/interface_equivalent.py
+++ b/predicates/interface_equivalent.py
@@ -118,9 +118,6 @@ def ie_def(m: Macro, pd: PreprocessorData, translation_config: TranslationConfig
                                               pd=pd,
                                               conditions=GLOBAL_CONDITIONS)
     if global_condition_check != IEResult.VALID:
-        if not m.IsObjectLike:
-            print(f"Function macro {m.Name} is not global {global_condition_check}")
-
         return global_condition_check, None
 
     if m.IsObjectLike:
@@ -162,5 +159,4 @@ def ie_def(m: Macro, pd: PreprocessorData, translation_config: TranslationConfig
         elif void_condition_check == IEResult.VALID:
             return void_condition_check, TranslationTarget.VOID_FUNCTION
         else:
-            print(f"Function macro {m.Name} is neither void nor non-void {non_void_condition_check} {void_condition_check}")
             return void_condition_check, None

--- a/translationstats.py
+++ b/translationstats.py
@@ -14,7 +14,6 @@ class MacroType(Enum):
     FUNCTION_LIKE = auto()
 
 class TechnicalSkip(Enum):
-    NOT_INTERFACE_EQUIVALENT = auto()
     BODY_CONTAINS_DECL_REF_EXPR = auto()
     DEFINITION_HAS_FUNCTION_POINTER = auto()
 

--- a/translationstats.py
+++ b/translationstats.py
@@ -1,38 +1,25 @@
 from dataclasses import dataclass, field
-from predicates.interface_equivalent import IEResult
+from predicates.interface_equivalent import IEResult, TranslationTarget
 from collections import Counter
 import csv
 from macros import Macro
-from enum import Enum
-
-# 3.10 compatibility for StrEnum
-class StrEnum(str, Enum): pass 
 from enum import Enum, auto
 
-class MacroType(StrEnum):
+
+class MacroType(Enum):
     """
     Types of macros that we can handle
     """
-    OBJECT_LIKE = "object_like"
-    FUNCTION_LIKE = "function_like"
+    OBJECT_LIKE = auto()
+    FUNCTION_LIKE = auto()
 
-class TranslatorAction(StrEnum):
+class TranslatorAction(Enum):
     pass
 
-class TranslationType(TranslatorAction):
-    VOID = "void"
-    NON_VOID = "non_void"
-    ENUM = "enum"
-    CONST_STATIC = "const_static"
-
 class SkipType(TranslatorAction):
-    BODY_CONTAINS_DECL_REF_EXPR = "body_contains_decl_ref_expr"
-    DEFINITION_HAS_FUNCTION_POINTER = "definition_has_function_pointer"
-
-    # Object-like specifics
-    CANT_FIT_ICE_IN_ENUM_SIZE = "cant_fit_ice_in_enum_size"
-    INVOCATION_REQUIRES_CONSTANT_EXPRESSION = "invocation_requires_constant_expression"
-    NOT_INTERFACE_EQUIVALENT = "not_interface_equivalent"
+    NOT_INTERFACE_EQUIVALENT = auto()
+    BODY_CONTAINS_DECL_REF_EXPR = auto()
+    DEFINITION_HAS_FUNCTION_POINTER = auto()
 
 @dataclass(slots=True)
 class MacroRecord:
@@ -49,11 +36,11 @@ class SkipRecord(MacroRecord):
 @dataclass(slots=True)
 class TranslationRecord(MacroRecord):
     macro_translation: str
-    translation_type: TranslationType
+    translation_type: TranslationTarget
 
 @dataclass()
 class TranslationRecords:
-    records_by_type: Counter[tuple[MacroType, TranslatorAction]] = field(default_factory=Counter)
+    records_by_type: Counter[tuple[MacroType, SkipType | TranslationTarget]] = field(default_factory=Counter)
     translation_records: list[TranslationRecord] = field(default_factory=list)
     skip_records: list[SkipRecord] = field(default_factory=list)
 
@@ -92,20 +79,16 @@ class TranslationRecords:
 
         print(f"Object-like stats:")
         print(f"  - Total translated: {self.total_translated_by_type(MacroType.OBJECT_LIKE)}")
-        print(f"    - Translated to enum: {self.records_by_type[(MacroType.OBJECT_LIKE,TranslationType.ENUM)]}")
-        print(f"    - Translated to const static: {self.records_by_type[(MacroType.OBJECT_LIKE,TranslationType.CONST_STATIC)]}")
+        print(f"    - Translated to enum: {self.records_by_type[(MacroType.OBJECT_LIKE,TranslationTarget.ENUM)]}")
+        print(f"    - Translated to const static: {self.records_by_type[(MacroType.OBJECT_LIKE,TranslationTarget.GLOBAL_VARIABLE)]}")
         print(f"  - Total skipped: {self.total_skipped_by_type(MacroType.OBJECT_LIKE)}")
         print(f"    - Skipped due to function pointer type: {self.records_by_type[(MacroType.OBJECT_LIKE,SkipType.DEFINITION_HAS_FUNCTION_POINTER)]}")
         print(f"    - Skipped due to DeclRefExpr: {self.records_by_type[(MacroType.OBJECT_LIKE,SkipType.BODY_CONTAINS_DECL_REF_EXPR)]}")
-        print(f"    - Untranslatable because enum size too small to represent ICE:"
-              f"{self.records_by_type[(MacroType.OBJECT_LIKE,SkipType.CANT_FIT_ICE_IN_ENUM_SIZE)]}")
-        print(f"    - Untranslatable contant expressions:"
-              f"{self.records_by_type[(MacroType.OBJECT_LIKE,SkipType.INVOCATION_REQUIRES_CONSTANT_EXPRESSION)]}")
 
         print(f"Function-like stats:")
         print(f"  - Total translated: {self.total_translated_by_type(MacroType.FUNCTION_LIKE)}")
-        print(f"    - Translated to void: {self.records_by_type[(MacroType.FUNCTION_LIKE,TranslationType.VOID)]}")
-        print(f"    - Translated to non-void: {self.records_by_type[(MacroType.FUNCTION_LIKE,TranslationType.NON_VOID)]}")
+        print(f"    - Translated to void: {self.records_by_type[(MacroType.FUNCTION_LIKE,TranslationTarget.VOID_FUNCTION)]}")
+        print(f"    - Translated to non-void: {self.records_by_type[(MacroType.FUNCTION_LIKE,TranslationTarget.NON_VOID_FUNCTION)]}")
         print(f"  - Total skipped: {self.total_skipped_by_type(MacroType.FUNCTION_LIKE)}")
         print(f"    - Skipped due to function pointer type: {self.records_by_type[(MacroType.FUNCTION_LIKE,SkipType.DEFINITION_HAS_FUNCTION_POINTER)]}")
         print(f"    - Skipped due to DeclRefExpr: {self.records_by_type[(MacroType.FUNCTION_LIKE,SkipType.BODY_CONTAINS_DECL_REF_EXPR)]}")


### PR DESCRIPTION
This change modifies `predicates/interface_equivalent.py` to provide specific feedback on why a macro is not translatable. It returns a reason from the `IEResult` enum (or `IEResult.VALID` if the macro is translatable).

The `MacroTranslator` class now has the responsibility of filtering out macros (originally done in `ie_pd`) so it can record any skip reason in the output CSV and the frequency count outputted at the end of translation.

Note that currently, only the first condition that makes a macro untranslatable is reported. We loop through every invocation, and every possible condition, and return the first failure if any.