### PR TITLE
Include macro body in CSV if translation is skipped

### DIFF
--- a/macrotranslator.py
+++ b/macrotranslator.py
@@ -40,7 +40,7 @@ class MacroTranslator:
         if translation_target is not None:
             skip_reason = self.should_skip_due_to_technical_limitations(macro, invocations)
             if skip_reason:
-                return SkipRecord(macro, skip_reason)
+                return SkipRecord(macro, invocations, skip_reason)
 
         match translation_target:
             case TranslationTarget.VOID_FUNCTION:
@@ -52,7 +52,7 @@ class MacroTranslator:
             case TranslationTarget.ENUM:
                 return self.translate_macro_to_enum(macro, invocations)
             case None:
-                return SkipRecord(macro, ie_result)
+                return SkipRecord(macro, invocations, ie_result)
 
     def should_skip_due_to_technical_limitations(self, macro: Macro, invocations: set[Invocation]) -> TechnicalSkip | None:
         """
@@ -92,20 +92,20 @@ class MacroTranslator:
         invocation = next(iter(invocations))
 
         translation = f"static inline {invocation.TypeSignature} {{ {macro.Body}; }}"
-        return TranslationRecord(macro, translation, TranslationTarget.VOID_FUNCTION)
+        return TranslationRecord(macro, invocations, translation, TranslationTarget.VOID_FUNCTION)
     
     def translate_macro_to_non_void_function(self, macro: Macro, invocations: set[Invocation]) -> TranslationRecord:
         invocation = next(iter(invocations))
 
         translation = f"static inline {invocation.TypeSignature} {{ return {macro.Body}; }}"
-        return TranslationRecord(macro, translation, TranslationTarget.NON_VOID_FUNCTION)
+        return TranslationRecord(macro, invocations, translation, TranslationTarget.NON_VOID_FUNCTION)
 
     def translate_macro_to_global_variable(self, macro: Macro, invocations: set[Invocation]) -> MacroRecord:
         invocation = next(iter(invocations))
 
         translation = f"static const {invocation.TypeSignature} = {macro.Body};"
-        return TranslationRecord(macro, translation, TranslationTarget.GLOBAL_VARIABLE)
+        return TranslationRecord(macro, invocations, translation, TranslationTarget.GLOBAL_VARIABLE)
 
     def translate_macro_to_enum(self, macro: Macro, invocations: set[Invocation]) -> MacroRecord:
         translation = f"enum {{ {macro.Name} = {macro.Body} }};"
-        return TranslationRecord(macro, translation, TranslationTarget.ENUM)
+        return TranslationRecord(macro, invocations, translation, TranslationTarget.ENUM)

--- a/translationstats.py
+++ b/translationstats.py
@@ -105,7 +105,7 @@ class TranslationRecords:
     def output_csv(self, filename: str):
         with open(filename, 'w', newline='') as csvfile:
             writer = csv.writer(csvfile, quoting=csv.QUOTE_MINIMAL)
-            writer.writerow(["Macro", "Macro Type", "Action", "Translation", "Action Type", "Invocation Amount"])
+            writer.writerow(["Macro", "Macro Type", "Action", "Translation or Macro Body", "Action Type", "Invocation Amount"])
 
             for translation_record in self.translation_records:
                 writer.writerow([translation_record.macro.Name,
@@ -120,7 +120,7 @@ class TranslationRecords:
                 writer.writerow([skip_record.macro.Name,
                                  self._get_macro_type(skip_record.macro),
                                  "Skipped",
-                                 "",
+                                 skip_record.macro.Body,
                                  skip_record.skip_type,
                                  len(skip_record.invocations)]
                                 )

--- a/translationstats.py
+++ b/translationstats.py
@@ -105,14 +105,15 @@ class TranslationRecords:
     def output_csv(self, filename: str):
         with open(filename, 'w', newline='') as csvfile:
             writer = csv.writer(csvfile, quoting=csv.QUOTE_MINIMAL)
-            writer.writerow(["Macro", "Macro Type", "Action", "Translation", "Action Type"])
+            writer.writerow(["Macro", "Macro Type", "Action", "Translation", "Action Type", "Invocation Amount"])
 
             for translation_record in self.translation_records:
                 writer.writerow([translation_record.macro.Name,
                                  self._get_macro_type(translation_record.macro),
                                  "Translated",
                                  translation_record.macro_translation,
-                                 translation_record.translation_type]
+                                 translation_record.translation_type,
+                                 len(translation_record.invocations)]
                                 )
 
             for skip_record in self.skip_records:
@@ -120,5 +121,6 @@ class TranslationRecords:
                                  self._get_macro_type(skip_record.macro),
                                  "Skipped",
                                  "",
-                                 skip_record.skip_type]
+                                 skip_record.skip_type,
+                                 len(skip_record.invocations)]
                                 )

--- a/translationstats.py
+++ b/translationstats.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from predicates.interface_equivalent import IEResult, TranslationTarget
 from collections import Counter
 import csv
-from macros import Macro
+from macros import Macro, Invocation
 from enum import Enum, auto
 
 
@@ -23,6 +23,7 @@ class MacroRecord:
     Base class for all macro records
     """
     macro: Macro
+    invocations: set[Invocation]
 
 SkipType = TechnicalSkip | IEResult
 


### PR DESCRIPTION
Include the macro body in the CSV for skipped macros. Allows us to find examples of skipped macros easier.