### PR TITLE
Add cache to analysis 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ python3 run_maki_on_compile_commands.py \
     -c <path to compile_commands.json> \
     -o <path to output maki analysis file, default is analysis.maki> \
     -j <number of threads, default is number of CPUs on system> \
-    -v <verbose>
+    -v <verbose> \
+    --cache-dir <optional, use directory to store intermediate analysis results> 
 ``` 
 
   

--- a/run_maki_on_compile_commands.py
+++ b/run_maki_on_compile_commands.py
@@ -88,7 +88,7 @@ def run_maki_on_compile_command(cc: CompileCommand, maki_so_path: str, cache: An
     args = cc.arguments.copy()
 
     args[0] = "clang-17"
-    # pass cpp2c plugin shared library file
+    # pass maki plugin shared library file
     args.insert(1, f'-fplugin={maki_so_path}')
     args.append(cc.file)
     # at the very end, specify that we are only doing syntactic analysis

--- a/run_maki_on_compile_commands.py
+++ b/run_maki_on_compile_commands.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+
 import argparse
 import logging
 import shlex
@@ -7,10 +8,10 @@ from dataclasses import dataclass
 import os
 import json
 import subprocess
-from functools import partial
 import concurrent.futures
 from typing import Any
 import pathlib
+import hashlib
 
 logger = logging.getLogger(__name__)
 
@@ -39,15 +40,26 @@ class CompileCommand:
             file=json_file["file"]
         )
 
+    def get_cache_key(self) -> str:
+        """
+        Cache key for use with AnalysisCache.
+        Note that this does NOT hash file contents, only the arguments of each CompileCommand!
+        """
+        sha1 = hashlib.sha1()
+        sha1.update(repr(self.arguments).encode())
+        return sha1.hexdigest()
+
 class AnalysisCache:
     def __init__(self, cache_dir: str) -> None:
-        self.cache_dir = pathlib.Path(cache_dir)
+        self.cache_dir = pathlib.Path(cache_dir).resolve()
         self.cache_dir.mkdir(exist_ok=True)
 
-    def get_cached_result(self, cc: CompileCommand) -> list[dict[str, Any]] | None:
-        cc_hash = hash(cc)
+    def get_cache_path(self, cc: CompileCommand) -> pathlib.Path:
+        cc_hash = cc.get_cache_key()
+        return self.cache_dir / f"{cc_hash}.json"
 
-        cache_path = self.cache_dir / f"{cc_hash}.json"
+    def get_cached_result(self, cc: CompileCommand) -> list[dict[str, Any]] | None:
+        cache_path = self.get_cache_path(cc)
 
         if cache_path.exists():
             try:
@@ -61,22 +73,22 @@ class AnalysisCache:
         
 
     def cache_result(self, cc: CompileCommand, results: list[dict[str, Any]]) -> None:
-        cc_hash = hash(cc)
-
-        cache_path = self.cache_dir / f"{cc_hash}.json"
-
-        with open(cache_path, 'w') as f:
+        cache_path = self.get_cache_path(cc)
+        with open(cache_path, 'w+') as f:
             json.dump(results, f)
 
 
-def run_maki_on_compile_command(cc: CompileCommand, maki_so_path: str, cache: AnalysisCache) -> list[dict[str, Any]]:
+def run_maki_on_compile_command(cc: CompileCommand, maki_so_path: str, cache: AnalysisCache | None) -> list[dict[str, Any]]:
 
-    if (result := cache.get_cached_result(cc)) is not None:
-        return result
+    if cache is not None:
+        if (result := cache.get_cached_result(cc)) is not None:
+            return result
 
-    # pass cpp2c plugin shared library file
-    args = cc.arguments
+    # Make copy to avoid changing args in place
+    args = cc.arguments.copy()
+
     args[0] = "clang-17"
+    # pass cpp2c plugin shared library file
     args.insert(1, f'-fplugin={maki_so_path}')
     args.append(cc.file)
     # at the very end, specify that we are only doing syntactic analysis
@@ -103,7 +115,8 @@ def run_maki_on_compile_command(cc: CompileCommand, maki_so_path: str, cache: An
             logger.warning(f"{process.stderr.decode()}")
 
         result = json.loads(process.stdout.decode())
-        cache.cache_result(cc, result)
+        if cache is not None:
+            cache.cache_result(cc, result)
 
         return result
     except subprocess.CalledProcessError as e:
@@ -144,8 +157,10 @@ def main():
     ap.add_argument('-j', '--num_jobs', type=int, default=os.cpu_count(),
                     help='Number of threads to use. Default is number of CPUs on system')
     ap.add_argument('-v', '--verbose', action='store_true')
-    ap.add_argument('--cache-dir', type=pathlib.Path, default=pathlib.Path('.maki_cache'),
-                    help='Directory to store cached analysis results')
+    ap.add_argument('--cache-dir', type=pathlib.Path, required=False,
+                    help='(Optional) Enable caching analysis results and place them in this path.\n'
+                          'Note that this will serve outdated results if the source files in the input program changes,\n'
+                          'or if a version of Maki with different output is used!')
     args = ap.parse_args()
 
     plugin_path = os.path.abspath(args.plugin_path)
@@ -172,23 +187,25 @@ def main():
                            for split_cc in split_compile_commands_by_src_file(cc)]
 
     # Run maki on each compile command threaded
-    cache = AnalysisCache(args.cache_dir)
-    with concurrent.futures.ProcessPoolExecutor(max_workers=num_jobs) as executor:
-        results = list(
-            executor.map(
-                partial(run_maki_on_compile_command, maki_so_path=plugin_path, cache=cache),
-                split_compile_commands
-            )
-        )
-
-    # Collect results (JSON Arrays) into one large JSON Array
-    # Doing this to avoid duplicates, which there was many of especially for compiler builtins
+    cache = AnalysisCache(args.cache_dir) if args.cache_dir is not None else None
     results_set = set()
-    for result in results:
-        # merge into set
-        for obj in result:
-            obj_tuple = tuple(obj.items())
-            results_set.add(obj_tuple)
+    with concurrent.futures.ProcessPoolExecutor(max_workers=num_jobs) as executor:
+        total = len(split_compile_commands)
+        processed = 0
+
+        # Mapping of CompileCommand to future
+        results = {executor.submit(run_maki_on_compile_command, cc, plugin_path, cache): cc for cc in split_compile_commands}
+                
+        for future in concurrent.futures.as_completed(results):
+            result = future.result()
+            if result:
+                processed += 1
+                print(f"{processed} / {total} completed...")
+                for obj in result:
+                    obj_tuple = tuple(obj.items())
+                    results_set.add(obj_tuple)
+            else:
+                logger.error(f"{results[future].file} failed processing!")
 
     results = [dict(obj) for obj in results_set]
 


### PR DESCRIPTION
Implement an (optional) cache to the analysis process to aid in analyzing extremely large programs, i.e the Linux kernel without losing progress in case of system crashes, etc.

If `--cache-dir` is specified, an `AnalysisCache` object will be created. Each cache entry is mapped to a `CompileCommand` hashed by it's arguments for simplicity. Obviously, this could result in outdated cache entries being served if the Maki library changes, or if the source file changes. Since this isn't enabled by default though, I would rather keep the logic simple for what it is.

Also, refactor our result processing to happen as each clang instance finishes running, instead of putting it all in a set once we have all results.